### PR TITLE
Remove RC and prerelease buildlog entries.

### DIFF
--- a/cloaked-search.json
+++ b/cloaked-search.json
@@ -1,15 +1,5 @@
 [
   {
-    "version": "0.1.34-pre",
-    "container_hash": "9d8895abeda08472d06f79fd239fd0a2e6723aa483d2945dc1a6c1a96823c42c",
-    "git_hash": "7a0b88eb3731d7c2ae522638f5c6a630ff1a9657"
-  },
-  {
-    "version": "0.1.36-pre",
-    "container_hash": "29ba273de7dc4547146c323cd927761ffc2ecded1a29bdc5073db0addaff3605",
-    "git_hash": "f7dadd02d00f3aeb2083ec65fd10062fea4c1111"
-  },
-  {
     "version": "0.1.37",
     "container_hash": "08a078e9087b223ac00de8c60ed6ee53d5cb5ceb000ce1172387a444608ee3b4",
     "git_hash": "fa8384d412bc41b639edbbd6625c9884d8d428f9"
@@ -33,11 +23,6 @@
     "version": "0.1.37",
     "container_hash": "82b5fdd5bf127a71cf17cafc2a7de7d27c83ef3093c1bf57428de2567419f0e0",
     "git_hash": "fa8384d412bc41b639edbbd6625c9884d8d428f9"
-  },
-  {
-    "version": "0.1.37-pre",
-    "container_hash": "a4934c5ceaaafad8bcb20d064b8aa6c6a40498757bd7878c24efd745700c85c7",
-    "git_hash": "17e5077199867549f914209f6f6376775c85aa04"
   },
   {
     "version": "0.1.42",
@@ -70,51 +55,6 @@
     "git_hash": "7708260dd6927fdab5291ef5599d60455fe8841c"
   },
   {
-    "version": "0.1.62-pre.63",
-    "container_hash": "dd7b2ec63968eecbfad40008db58c926d62aacb1b3b134af4c7e6a8d75664fa0",
-    "git_hash": "df8e8ce97200f308d45d460ecfe49b3581b10cea"
-  },
-  {
-    "version": "0.1.62-pre.64",
-    "container_hash": "54c770a90941c441bce88bc3a05e06cf8e79fbef7040bb48d8f67226d4f39051",
-    "git_hash": "fb9f8c874c44c0737c54799c7b932ffc3680ff7f"
-  },
-  {
-    "version": "0.1.62-pre.65",
-    "container_hash": "e64a404b29b4c9e91bd7d78cdf52b64db1340a238935de88db7a3c2bb152ec36",
-    "git_hash": "1fcbb468352ba6a1cd002527580acdcf3659ea2e"
-  },
-  {
-    "version": "0.1.62-pre.66",
-    "container_hash": "e6280372dd87414df3048907aebafe2f0c57839ad67196df4c4a1d7d30a1cadd",
-    "git_hash": "4d7c67a639a9c0c2e337e08ff73acfa1ff26ef42"
-  },
-  {
-    "version": "0.1.62-pre.67",
-    "container_hash": "ea1e3d1f1aa0af37906c053a2f3ea44e962c24e637a544bc9f9558f850f73618",
-    "git_hash": "30566cdcc3faa95111c524da9539bd5d0fb658fb"
-  },
-  {
-    "version": "0.1.62-pre.68",
-    "container_hash": "af28bb700048abc817d178c02d14c2e40895f5ee01fa9258f2c224808000de51",
-    "git_hash": "8d2d1b20e439f4a379add83f2c4ec6bc5bce3aab"
-  },
-  {
-    "version": "0.1.62-pre.69",
-    "container_hash": "a88a4d4e4fbc158e8c59ac2a98e0794a2bbfe0b40771de1b5d1581b092bc83da",
-    "git_hash": "5e656dc200e234e0db141def149c1275fc76a8dc"
-  },
-  {
-    "version": "0.1.62-pre.70",
-    "container_hash": "9c239dc3e5efcdad4f4edc471bd1efafebf51c2e123b4f09ac183a455ab86b65",
-    "git_hash": "d992f1f08916810dc540e8bda210c3316b6b3343"
-  },
-  {
-    "version": "0.1.62-pre.71",
-    "container_hash": "d2e7a83257141f811472c814a69e3856ce25dd59ec1d9741b4b1c5f4caf2165c",
-    "git_hash": "d367a42281afd3b332187c114be4d99b9976d6ae"
-  },
-  {
     "version": "0.2.0",
     "container_hash": "3ba3d1436d7cebf4678e352015c50293ec0cd74a89623d43f43a2c94d75e76c4",
     "git_hash": "fd8a18747c3ad6f4ef99162e82d69bb5b896e97e"
@@ -123,41 +63,6 @@
     "version": "0.2.0",
     "container_hash": "ffbdd6f56e8084bcaeb12871f04d23ef6f5f016c6770f865619119aa44a26b7d",
     "git_hash": "fd8a18747c3ad6f4ef99162e82d69bb5b896e97e"
-  },
-  {
-    "version": "0.2.1-pre.2",
-    "container_hash": "0e09d1335962345a9df18b5f55cc7b1e4f0ae9bcce6f4f2c14bb3824f67e60cb",
-    "git_hash": "a789e91a61c65d25c93af0cc15ba8a987471d534"
-  },
-  {
-    "version": "0.2.1-pre.3",
-    "container_hash": "482cd718f3fce3d68cf83a61d35c3621e340c5fd7480641d60aa774765f50cba",
-    "git_hash": "1f54cbca347c8ec0773cf5243a3465137d3bd2dd"
-  },
-  {
-    "version": "0.2.1-pre.4",
-    "container_hash": "8a2759509606e7fa87d39743ea1207fb7bf0f13d847dee6fe739a50a6c12a2d4",
-    "git_hash": "41376c631e3bfaebb758b0cca0e5a28af1430985"
-  },
-  {
-    "version": "0.2.1-pre.5",
-    "container_hash": "fbca182085b20c4a15d47985d141a9abf936ebb43070e7bf8a9af48cc727bd66",
-    "git_hash": "bb9909be2a466a36b276e9dead155dc77e912f7b"
-  },
-  {
-    "version": "0.2.1-pre.6",
-    "container_hash": "022e9e34986b9f51966ae4ac501cd652ec375be99b9068b51e0b6ce28e03b3db",
-    "git_hash": "7dbfd22bcf7fbbfa58b05db6c14a81ffc70cdd4d"
-  },
-  {
-    "version": "0.2.1-pre.7",
-    "container_hash": "cacaa8a2f9c7b858f68a787ce2c775b87ce5af7b033c38d0ddc14e6d1ecd08ce",
-    "git_hash": "68699818af837c52c2a65aac0be2da99d0f487cd"
-  },
-  {
-    "version": "0.2.1-pre.8",
-    "container_hash": "da960a6bd4f3b51b8e24dbaceba158d2ea701d45af3c04cbd0e66653f158ca44",
-    "git_hash": "09751feb652d3523a9d5c032d540edc0df7c292c"
   },
   {
     "version": "0.3.0",
@@ -170,51 +75,6 @@
     "git_hash": "2121f80c9dcb99333f7090d73dd54f6929bd766e"
   },
   {
-    "version": "0.3.1-pre.10",
-    "container_hash": "f45cfc67332bec688b7e64c1ad9570961d83af0f30ea70764df310548997fe78",
-    "git_hash": "a5b465731c60c9c9a7277fb366266a27733f110b"
-  },
-  {
-    "version": "0.3.1-pre.2",
-    "container_hash": "9b047664a81c556bd21457a9a9cd49bdf6d452fbea8bb595fb22026ed020de2f",
-    "git_hash": "d4629268ae9d7655d021c64c54f8ea35ea335e6d"
-  },
-  {
-    "version": "0.3.1-pre.3",
-    "container_hash": "b58ccdad7397cfcf227565a2f7d4fb7d07bb68103f0291b1b4116b000046bc6d",
-    "git_hash": "478c0be75986619deaae47485e8786fd91e2c129"
-  },
-  {
-    "version": "0.3.1-pre.4",
-    "container_hash": "7d193d517029970c1839e2a379249069fa35ff08e67765a22dddd1c253a0d4d0",
-    "git_hash": "c5d4c8891c75807a4cd59cccfb15f94ff1d565d7"
-  },
-  {
-    "version": "0.3.1-pre.5",
-    "container_hash": "2afd9ce5bbce48ac89f54e5f0f056ed9c0655211d2c10fa04e0092a6204ac389",
-    "git_hash": "16855a8faa612af9757c158e3d45d4ea624b28d3"
-  },
-  {
-    "version": "0.3.1-pre.6",
-    "container_hash": "7f90b2cdc3c93a8a2822c41e2ba4d09863736a73a09b71ae73be5d0ce55eda5f",
-    "git_hash": "b4be2b6aa141fea0c8af5a2cac5621ebb3f3b957"
-  },
-  {
-    "version": "0.3.1-pre.7",
-    "container_hash": "1ad65d832782a162d55ab65ce126eccf88e8001f09c6a08f06a4bb5ef53ab301",
-    "git_hash": "333ac619b42f4dc48a5fc30759baa1a40f228796"
-  },
-  {
-    "version": "0.3.1-pre.8",
-    "container_hash": "13ab2222161bb278efc947c24c8793b2843806004f43f246d50daccdd62bc000",
-    "git_hash": "ce92021af4679d9a953819cbda2105975358823a"
-  },
-  {
-    "version": "0.3.1-pre.9",
-    "container_hash": "06b3c71e8fc6ed8dfdee5220893bd6f382974b074a1fc19c1531143c685721b3",
-    "git_hash": "da51a1ab4de6c05dd4576f24b9fb2e89e6ec5721"
-  },
-  {
     "version": "0.4.0",
     "container_hash": "38511abecee5d6aa9e5c1c92d679c0faccf8ba811618d1e69c2069f9ff006138",
     "git_hash": "79265928532ab7fcc8af7614686ee9e041e6b9d7"
@@ -225,96 +85,6 @@
     "git_hash": "79265928532ab7fcc8af7614686ee9e041e6b9d7"
   },
   {
-    "version": "0.4.0-pre.1",
-    "container_hash": "4be44206c658a4af2880485157f80a6b32b73f8354057ad9edfcac07f46fa6e2",
-    "git_hash": "7ac9acca90208ecd3558cd4849bc113ac5e826b1"
-  },
-  {
-    "version": "0.4.0-pre.2",
-    "container_hash": "9163297ef25b47b5bc7887237be243c77745e25fd1a21310fba79f8b3ef87903",
-    "git_hash": "ad3e412a4adafe4cbaceb24ab3c4b87972cfffc5"
-  },
-  {
-    "version": "0.4.0-pre.3",
-    "container_hash": "6b39bd0b840181434ad32319a2abdeb6dcad5c490e827f3f734fee4efcf01cff",
-    "git_hash": "26a1ee420caf14b8dac03adb846b4fab750aa08a"
-  },
-  {
-    "version": "0.4.0-pre.4",
-    "container_hash": "7d5295ceda41faaed2a1a00a3a0d01fa17004115de0607859bb66cf661f344b9",
-    "git_hash": "523b4348247be094723a560fdd35e82258999896"
-  },
-  {
-    "version": "0.4.0-pre.5",
-    "container_hash": "2dab30653515658e126cd89401fef0b6d7a76d7a12d3ee2e4da6fa574903170c",
-    "git_hash": "663b894484faf7ca69563137db560fc30882c325"
-  },
-  {
-    "version": "0.4.1-pre.10",
-    "container_hash": "8ce670235ebe235f78ef7949d556b44f04326c316a84f273e322e09bd09778b6",
-    "git_hash": "291c010aab9a9bd4769cd6245f6e986d2b511ea3"
-  },
-  {
-    "version": "0.4.1-pre.11",
-    "container_hash": "48c69a84734a5d2b1e9939bcea130bf91c03b2899c1b677bac32f1755f64bd29",
-    "git_hash": "e7327119bbc912dca27997e656769d0f780f4732"
-  },
-  {
-    "version": "0.4.1-pre.12",
-    "container_hash": "d26514a80f564288c2c1cf6e107a3804f94dc842fa97e768238ce9cfb524bbdc",
-    "git_hash": "5f70e2fdd9825e49b5cffe38cd89f13566f7b871"
-  },
-  {
-    "version": "0.4.1-pre.13",
-    "container_hash": "00d111a520e0253bc2ac2e4dc9ea84bedbf072d4fd5d973e085e7013b9ee1d9e",
-    "git_hash": "829069f96fa13116322088c82bc22963bca78557"
-  },
-  {
-    "version": "0.4.1-pre.14",
-    "container_hash": "2338859676d58ca3eae2558f82372ee655eea2ec06991023a459e9d6a0ce9ce6",
-    "git_hash": "1ec3e58e9efdec423620cf3c33461095dd3badab"
-  },
-  {
-    "version": "0.4.1-pre.2",
-    "container_hash": "97282bd7981cf4e44b97519cb9e2b16141d447574ddc0a43f14a545c526d9b1e",
-    "git_hash": "5fbadcfa9c58df072f55186e5225100e02e0ca84"
-  },
-  {
-    "version": "0.4.1-pre.3",
-    "container_hash": "92ce03ecc822489187879e77130c7a2ca5307c2581fa66fa56b2a5f2fd99f911",
-    "git_hash": "cf70330418592afbdf5ffe416cd3861545992da0"
-  },
-  {
-    "version": "0.4.1-pre.4",
-    "container_hash": "b579b78df3a479ee1aae3d08f913e20f2ab29a4baf7393d744ff773f22318c0e",
-    "git_hash": "2fc7afd2156b6daec06bb786f3dfad508e4a4b6d"
-  },
-  {
-    "version": "0.4.1-pre.5",
-    "container_hash": "8b035869e70a02374f8f4b4eba9d5c1666bbb774504614c4f48ab2d4676567fd",
-    "git_hash": "4ec0d7d369d79c8d2ad31b1525980b5d983f20ac"
-  },
-  {
-    "version": "0.4.1-pre.6",
-    "container_hash": "ea255c817b75e6295efe55b7186ccdde521b246858af3f8825ed4ef277a7a164",
-    "git_hash": "bc4a227a6d40e5a8aba1df91c0f3122b24e85b21"
-  },
-  {
-    "version": "0.4.1-pre.7",
-    "container_hash": "c9f4b0073e2168ca9e2e14762b072a6fd6692e30e2aa56e002146856214a6c64",
-    "git_hash": "e70659fd0c54df8a1e48f3060efdd63696660e39"
-  },
-  {
-    "version": "0.4.1-pre.8",
-    "container_hash": "e41be195a904496d72bf2c95ef1cb9d17b662d86c9f15ba0ecaa3b5910dca969",
-    "git_hash": "8399768a5c2e737d70bffb02d9a82088e02b853f"
-  },
-  {
-    "version": "0.4.1-pre.9",
-    "container_hash": "c45266f1e48dd93183e2cf69c793c9f240788c9c3d266ffc45dc68fe81f49d60",
-    "git_hash": "8ab9b049894f02fa4c0d700265a9c3beacf16af5"
-  },
-  {
     "version": "0.5.0",
     "container_hash": "60d14341ceaf415386cec6bec9161323d59ea761a267914cc8e5a03071be52b3",
     "git_hash": "84735aa34a13e1da054d68af8073b19245200d13"
@@ -323,76 +93,6 @@
     "version": "0.5.0",
     "container_hash": "941fd171b046fb74025295cebc74a92aab0b03b3a5af721dcd89f24a0644a0f0",
     "git_hash": "84735aa34a13e1da054d68af8073b19245200d13"
-  },
-  {
-    "version": "0.5.1-pre.10",
-    "container_hash": "fd336f3382a39b1f10d45a4851fe79ff6286014257be0b10655706ab5db38328",
-    "git_hash": "f59c1b6b66a9f005625ac20b442d04fafe6dc712"
-  },
-  {
-    "version": "0.5.1-pre.11",
-    "container_hash": "4178ae555cc53349154345a62b945ec04df73c0e19d48a92dee6209947cd3051",
-    "git_hash": "1d2e437aa33904b0d4e36162309071fa445f55e4"
-  },
-  {
-    "version": "0.5.1-pre.12",
-    "container_hash": "b70624a71a6a275ad429769dd9ed9f536d4c9cedf0d040db1136d4578dcd8ed6",
-    "git_hash": "630af6f3449ecbb1a903715c6606e39e882f9234"
-  },
-  {
-    "version": "0.5.1-pre.13",
-    "container_hash": "d66e14a82cdc14c53b643a821b43c4c5c074e0a837198039cace303dc1a4afcc",
-    "git_hash": "8d98cdf9848e4a321449d63c29d241e4cf02a3a6"
-  },
-  {
-    "version": "0.5.1-pre.14",
-    "container_hash": "b60567265cb96541ef56c85b83dcce6bcfbe685884e220493b27db3aa44f6c56",
-    "git_hash": "5f71d7436136389e2e08ef9e1caac489f577fa45"
-  },
-  {
-    "version": "0.5.1-pre.15",
-    "container_hash": "5272734df862d94a13353aee7a40fb21b71a5c7537f00d285f4cd9f7cff26b17",
-    "git_hash": "145a379a66fcbe88302923d46f36b54976968b12"
-  },
-  {
-    "version": "0.5.1-pre.2",
-    "container_hash": "fb52062b0842e3c8343033d9689b6a7107e72a2399a9e3c55b4f37750cd4b527",
-    "git_hash": "9c080307f5d68d35953c6597486c08ae370482b9"
-  },
-  {
-    "version": "0.5.1-pre.3",
-    "container_hash": "92dbfb40981ccd85283827a056a90e90948afc8c3de5c6303480ce06615d2c64",
-    "git_hash": "a26520cfa9483cccc786f80dc0d8a52ca3d67c38"
-  },
-  {
-    "version": "0.5.1-pre.4",
-    "container_hash": "c66ba937de00d8ab75306ffca884145ab494784d095c91d69edbcd1ace753eca",
-    "git_hash": "04d4189038d646535869399fbdcddf61be92d8c3"
-  },
-  {
-    "version": "0.5.1-pre.5",
-    "container_hash": "b55636e5cbf24f01544c7c85daf075b678edb863e2239b371fa004d4d9ae5994",
-    "git_hash": "ac94f9dadb4354a9d99e1d51c80de26567867731"
-  },
-  {
-    "version": "0.5.1-pre.6",
-    "container_hash": "085df800710af0963c01825d1d3e6b6d163b651e5b09faf520d94823654b4df5",
-    "git_hash": "e823986ab44e6343eac08038d6e5ec8250b56b8d"
-  },
-  {
-    "version": "0.5.1-pre.7",
-    "container_hash": "72f85149537fd8128880faea0c276cce3e65099b12cba8251d0904a96df6392a",
-    "git_hash": "b02e058f58d2af94e89fa1ac6b5d3a3fb304d14b"
-  },
-  {
-    "version": "0.5.1-pre.8",
-    "container_hash": "3be2831bcd02885fbfea2b2651fba7bc4b69e113e9719bee4ac9013916dae84d",
-    "git_hash": "a772604885b91cd46a662eb1e9f5effbac6a5627"
-  },
-  {
-    "version": "0.5.1-pre.9",
-    "container_hash": "83540ca900315f6fe10916422a8eebf26e088a998fa2e39854a91ad0ca67ca62",
-    "git_hash": "6c1bbaeae519dc8c811d6dde63432eb3d862d455"
   },
   {
     "version": "0.6.0",
@@ -415,81 +115,6 @@
     "git_hash": "c7a168fbc32076f751e5b24cd7f4a299b9f3d95e"
   },
   {
-    "version": "0.6.1-pre.2",
-    "container_hash": "7ef3af2d53c902bce0faf22f621af818e20ccf993bcd0c6795cca0c22acf3556",
-    "git_hash": "40c12bca26abc89a13b5cdcf34ad2e08fb1f1708"
-  },
-  {
-    "version": "0.6.1-pre.3",
-    "container_hash": "35c5e23068d469273fe3851fbc919fb8569f99cf3906395b278ce16722fbfa62",
-    "git_hash": "0ec5c65f1b159526bc1a766f3ec1d6d8798ec1aa"
-  },
-  {
-    "version": "0.6.1-pre.4",
-    "container_hash": "a164fb661d82cccfeda76cd7d188bf6d4cfcc83f98de406956f138c5f7570465",
-    "git_hash": "0016db8f6f7ac52de025c2ad59d4c19c46f70fe3"
-  },
-  {
-    "version": "0.6.1-pre.5",
-    "container_hash": "9b4b4dbeea11ebf9d8f9661ff9bdd6178e30d19b0e2c095deee088d1c20ee279",
-    "git_hash": "f708df7998cabcb290710d3ef89afa178de6e9ea"
-  },
-  {
-    "version": "0.6.1-pre.6",
-    "container_hash": "4a0dbf56244e77a4bbcaad5b639f169877a2326b6f683e6098f381f3876522f4",
-    "git_hash": "23f6fb2dcd7a607a1aebc458ee82284657a32882"
-  },
-  {
-    "version": "0.6.2-pre.2",
-    "container_hash": "30f5611db5b8979852ac25f06f32a2a91a715583e7203a0dcfd9742d13e1ed47",
-    "git_hash": "cdb482c75aa07c177bfcd72785aa9bf8cfbdd39e"
-  },
-  {
-    "version": "0.6.2-pre.3",
-    "container_hash": "edab12538f4e9725faa0c01ff02a73776d2a5bb1a6f07aa9cec97b45ae64feb6",
-    "git_hash": "75556ba5e9fee0b1deb41ff47e3c80a9c1b08805"
-  },
-  {
-    "version": "0.6.2-pre.4",
-    "container_hash": "a9a7c0123ec810ce9e634ee59bc949ca33279398515c328ede74b8f350e34bec",
-    "git_hash": "33d803cf87915126a3bcca08b79f227ec207dbf0"
-  },
-  {
-    "version": "0.7.0-pre.1",
-    "container_hash": "171014aef4f22240b41a860a8ec26b19d6d648c933374fab2a3338ca2661a19a",
-    "git_hash": "019924f54fd75b84053697e23e874737b27d52ee"
-  },
-  {
-    "version": "0.7.0-pre.2",
-    "container_hash": "e01f44be54940d5883b3fdbe3d6511174e3f68900de1a898b43b1b869f8a1d08",
-    "git_hash": "ebe34f468230f6b9229a5ff126b34f723e996a5f"
-  },
-  {
-    "version": "0.7.0-pre.3",
-    "container_hash": "e4687a3407c63975a6ead214e2e705ee08cd261e6744de0bc9140e277739e430",
-    "git_hash": "d8a1023583f3ba08edf699c28f8621a7751d7657"
-  },
-  {
-    "version": "0.7.0-pre.4",
-    "container_hash": "35ac2dca88136ccebf2bcd23d141ba3ae4ee93aa013cf29c543611d8947e7dee",
-    "git_hash": "df2d207228cf9e7cd561caeeb05d68b876bb64c4"
-  },
-  {
-    "version": "0.7.0-pre.5",
-    "container_hash": "f8fd28808faf6143f111b54a45b1d02b43ec311b3ce71bbb693ed2fce77b6bc6",
-    "git_hash": "859a47cabc4cffd055bb70c00135d3cb44a55565"
-  },
-  {
-    "version": "0.7.0-pre.6",
-    "container_hash": "dc1f51af740588d6763e3756327c8c42cf1a2fa84badfb73565108f0d240b37b",
-    "git_hash": "d015cc97b0f1ec24af301416a519900bad70d6a7"
-  },
-  {
-    "version": "0.7.0-pre.7",
-    "container_hash": "15171bd99a3a3daa9fce67641ec7241b2decd0591bf11798bec8444f74913b64",
-    "git_hash": "cb0f74d78230ec8f1db117e2f21ac4cc60f7474c"
-  },
-  {
     "date": "2021-11-01",
     "version": "1.0.0"
   },
@@ -510,401 +135,10 @@
     "git_hash": "1ffe17cd10313ca99cf7f9e81080311970dc6ebf"
   },
   {
-    "version": "1.0.0-pre.1",
-    "container_hash": "ca351d9c40a19fd28f8eb4db745f3ac55d13f6e000983d1c0a38ad1932552b24",
-    "git_hash": "05b5a4586f7b881788e0908ea54fcf1ecb2eb004"
-  },
-  {
-    "version": "1.0.1-pre.10",
-    "container_hash": "0a837f19456b551d2687f09cef39ae3e13c3b66843b881606c9816f676f19d8f",
-    "git_hash": "440c71ff1b0e358c9e5fb08f7bcdc1f71ad85d50"
-  },
-  {
-    "version": "1.0.1-pre.11",
-    "container_hash": "ed9805b6030ea9f5ec59e0968e98ee3869c5e795ada4b78fa78171bc029d03c4",
-    "git_hash": "59a698e14083bf5205624beb4701cae4463fce6f"
-  },
-  {
-    "version": "1.0.1-pre.12",
-    "container_hash": "8662a057f5d3acf9ddb75d15079f560dbb5d7423f295be00d8468880e81c4578",
-    "git_hash": "ea311deb4f979e5800739a1b5384150e7043aea8"
-  },
-  {
-    "version": "1.0.1-pre.13",
-    "container_hash": "a15fba49a5dde3361b962929959fd23fd6b68904f4b93ed0cac2cb92e7c7b4a1",
-    "git_hash": "d25073631eb60b404d132360c72c31b4a2740de6"
-  },
-  {
-    "version": "1.0.1-pre.14",
-    "container_hash": "853fe6e2aa8287b5d2fb481c4c664acf3a807806f38d6a50e4c8f35480314d5e",
-    "git_hash": "0ceebbe35ef06bb97000255c9a9626722092e542"
-  },
-  {
-    "version": "1.0.1-pre.15",
-    "container_hash": "d7096c9fe30d1e6b5842e1604a5eb37c23ab79a7e0f48d2e416454abdf66c6be",
-    "git_hash": "9d10fa69e6b6cb18cb984a559ad916e81ab67821"
-  },
-  {
-    "version": "1.0.1-pre.16",
-    "container_hash": "4a30b3dfd662a28f270ce5f480f72856c478e9d29c4dc4d6c7d08b5e80a99927",
-    "git_hash": "6c39a492c2a8181377a89bc015ea08c69e503272"
-  },
-  {
-    "version": "1.0.1-pre.17",
-    "container_hash": "600f7b3011743a41987042b58e829c6e7bf12c079eabd914075159a09f058ba5",
-    "git_hash": "c18556fdb002c91a115d1adaf97ad64145a349af"
-  },
-  {
-    "version": "1.0.1-pre.18",
-    "container_hash": "d1945f452d6336d01f65c5c96b016db2f16fd72fc18c31dae038a3585ef38bc8",
-    "git_hash": "7fbec1779603331c2f7317ac9df45f7bdd1face5"
-  },
-  {
-    "version": "1.0.1-pre.19",
-    "container_hash": "28b1a684dc12e2e3aeabb719127875dcac5cb4e42d8d955efeedca7d34838f59",
-    "git_hash": "c2238aa8fc978514ec9e2a316aa72e86aa7e4a79"
-  },
-  {
-    "version": "1.0.1-pre.2",
-    "container_hash": "f1bf41c72ca3a7af7f664603f98ded6d313c7b500ec30617b4fbfd9e9af48143",
-    "git_hash": "619092eeda30586fe63206da558089d597aad102"
-  },
-  {
-    "version": "1.0.1-pre.20",
-    "container_hash": "f9f6c65462dbc19c690b5a601b53c83231cc98b685797cd6f692d3747f033d6a",
-    "git_hash": "3780e1c1382dfe56229f2726078b674319edfb17"
-  },
-  {
-    "version": "1.0.1-pre.21",
-    "container_hash": "67e6f8e73d990eb5c5feead6c767bb18f62c4e17cd88067346041156dcf4aa1b",
-    "git_hash": "e53b55a595b522c9cd1d72cf784333267e95f676"
-  },
-  {
-    "version": "1.0.1-pre.22",
-    "container_hash": "016a8ce07a5ab423e9a296418991f0d15eef175f123fe14918ea20e3df7eef40",
-    "git_hash": "f50458b3873f3d340523368bdf53be8517015083"
-  },
-  {
-    "version": "1.0.1-pre.23",
-    "container_hash": "f1108e46bbd02e9c5de5c3ae4405682f284e9c4ad5c6eba90fc22bec711b32fb",
-    "git_hash": "a4713b26ed62267f719b0d69d38c7fe292b43a52"
-  },
-  {
-    "version": "1.0.1-pre.24",
-    "container_hash": "9a5394639a50853a0e7147dfe84337bbe77fb06f2f1820db10655e5111d712e2",
-    "git_hash": "b4b206c13d629978f9926ff53e4b02c1a04a2ba8"
-  },
-  {
-    "version": "1.0.1-pre.25",
-    "container_hash": "bed813f8b03634d9ac3fcb606dc9b8ed9d3527eae54cddef0aa8c5dd7c1bc3f1",
-    "git_hash": "3eab9400ac75eb06d39fede662568462530dca33"
-  },
-  {
-    "version": "1.0.1-pre.26",
-    "container_hash": "0de016aed389ab92a6bb9372de32b927f6987face9530706cc717607939ee88d",
-    "git_hash": "09dfa046d3b3ed6402049ea9df18c9ba0e7d7cc9"
-  },
-  {
-    "version": "1.0.1-pre.27",
-    "container_hash": "c2c6094b68ac74367808ae87a95992a18c9e7f9e964d326bb1b74400e93786fd",
-    "git_hash": "8823103211fd0c80bcdb1bd29d29902fdc1ce592"
-  },
-  {
-    "version": "1.0.1-pre.28",
-    "container_hash": "9424d86cd6e06fd038bc5d5a418f0f6e2cbc1016a1152f0cdd96844e12fb5ab1",
-    "git_hash": "a04fce530845b74c57805de44b0f08d087048330"
-  },
-  {
-    "version": "1.0.1-pre.29",
-    "container_hash": "9212f3ac287d284b1ecb0b96aa297b6b92445f4066c8c6efaa72689ab55a8d6f",
-    "git_hash": "5b5febeccef7ce68a288faf069124111cfc38e6c"
-  },
-  {
-    "version": "1.0.1-pre.3",
-    "container_hash": "1727bba62afdbe4c9793bcb564fc8b8cae163bedfd9d360680e7a3543828ebf4",
-    "git_hash": "4e697f363dc7059e826ddad280df145cb384ae1b"
-  },
-  {
-    "version": "1.0.1-pre.30",
-    "container_hash": "d8fdb1d8a94c6e6a3715edd5a1925b9383b6bc08d7b6251bc70ec12df8951dd9",
-    "git_hash": "2203f95a4d95b4580c6eb33adfb4a08e720fb990"
-  },
-  {
-    "version": "1.0.1-pre.31",
-    "container_hash": "fa2997bb45cf936e89d73997c41d5ffa7d93bf665788ca4c78f33801f9aaf9d8",
-    "git_hash": "ae7a79746a806e8daadf000af2228ff3ca27d495"
-  },
-  {
-    "version": "1.0.1-pre.32",
-    "container_hash": "8ab07261665b80ac735f9bb7a64f0b3468477cb06e0981fd6a4e79cc1e178d5b",
-    "git_hash": "b0c746fccea02e76ccdbb733e8e6f41b51924924"
-  },
-  {
-    "version": "1.0.1-pre.33",
-    "container_hash": "32d722180026a343d4585e43cc1ce095174f69c00e8ef38547d5d5a3d92a411c",
-    "git_hash": "93aaff3b60387b63693e1e906f2a0870aa415e5b"
-  },
-  {
-    "version": "1.0.1-pre.34",
-    "container_hash": "9347c3df1230e78d6487605ba847c52608488d35bdc015af30d4ece97e51a70b",
-    "git_hash": "77894c417493a792a9f31948591458d2b98da9c1"
-  },
-  {
-    "version": "1.0.1-pre.35",
-    "container_hash": "429b7d7906835d255b0893ab4cbf0fe49bf50829aeb0dd7191d4432609fef123",
-    "git_hash": "3059ad175c82dd537bc913911997402e3b89aa18"
-  },
-  {
-    "version": "1.0.1-pre.36",
-    "container_hash": "19b12515c1c8ae785432cf26de8fe96f8cb13ba5b84a829d175c5898aac305e1",
-    "git_hash": "89facec25635d8ee71bc1809f33bed231f16a464"
-  },
-  {
-    "version": "1.0.1-pre.37",
-    "container_hash": "325aa3d7dfaf5ef2e3e6433fc53e86dd20176f2b104b0fb057f500ad0f08a114",
-    "git_hash": "b6eff8e4d6d29306cad866a68c52b2fe2ff02248"
-  },
-  {
-    "version": "1.0.1-pre.38",
-    "container_hash": "cda49606eaa05872495c7cfc698926a76dfd007248923d1583296a9a0bd4ea2c",
-    "git_hash": "8d1791759dfc0ae4023f912c58cbe94941fa24d7"
-  },
-  {
-    "version": "1.0.1-pre.4",
-    "container_hash": "b0d1526ca17bcb7ee1448dca7cb482df6d4257ed927b4fa7850c6c00c0ac7f94",
-    "git_hash": "d0111b824fa055abb8ae89ff2c9dc3563281f884"
-  },
-  {
-    "version": "1.0.1-pre.5",
-    "container_hash": "36b5a04cf5f67a41a78ca4ac61b90db77724484ff77ef2ec0367086d9c8497b0",
-    "git_hash": "b051b355585ad39c1ceef01e153b7e77350daae8"
-  },
-  {
-    "version": "1.0.1-pre.6",
-    "container_hash": "8dd84863ed24f732d9804a3df166d6b7716a28d0281e6e61911c0e9040590246",
-    "git_hash": "2278ec80b2b0e04f85d2ab01ee48d40d869dbd08"
-  },
-  {
-    "version": "1.0.1-pre.7",
-    "container_hash": "3db1720ee3afdce27460d2d6293e65150def794d5ec91b2467f05588cc11b60a",
-    "git_hash": "b735a80d78cad85d819ee3d7b91346f2d4c0ddd0"
-  },
-  {
-    "version": "1.0.1-pre.8",
-    "container_hash": "484ec84a928516b4420ed94719955acfe71ab32fde9e25d09496b05281c27ac2",
-    "git_hash": "3427cd0df6d9254486bf52615d2f703437dee61f"
-  },
-  {
-    "version": "1.0.1-pre.9",
-    "container_hash": "72a97abdc7064babbc0006b6674031f0ac6a2f6aa9c51159bb1ed322e4f4ccbd",
-    "git_hash": "4f71f751bae35ebd7737369d8f3ec306ccfd6918"
-  },
-  {
-    "version": "1.0.1-rc.38",
-    "container_hash": "3ffbcfdb57da1aa5ed07f3a57a3f8a41699b60477852f8ef39e3a77ffbb44be2",
-    "git_hash": "f2ed6a2c7a589234c6bafdb13bb713c3b4d9cf3c"
-  },
-  {
-    "version": "1.0.1-rc.39",
-    "container_hash": "4334281a65e73b9ec7852ec9011be1ea2d291942114085bd8d55a3c30a51a010",
-    "git_hash": "fdf52adf0c801ff652789483847fcff7812b1a25"
-  },
-  {
-    "version": "1.0.1-rc.40",
-    "container_hash": "f80841ba60a7f4c2825796e3165b5cfbedaffedaf81f6b3a72d2a5e9a0c61b02",
-    "git_hash": "d7ad0a37006763b998e4558f53e62727e3bb8631"
-  },
-  {
-    "version": "1.0.1-rc.41",
-    "container_hash": "12af0634ffd20b6113d25377240b4408d76eaa4b20a940665f4ab79a9881a032",
-    "git_hash": "b9c0d9444ede5a321e0dbd161fd40cc1a5ded9c3"
-  },
-  {
-    "version": "1.0.1-rc.42",
-    "container_hash": "5a85d390d1b07eb2e12bdcd653b22766073e4ed7e2eda34a9a99769934298d7b",
-    "git_hash": "dcaeaf22dc97595564eec612aa6d0dddac94c189"
-  },
-  {
-    "version": "1.0.1-rc.43",
-    "container_hash": "874dcfa5a3ba7d20dd91f424d3fd729e0b74dd7f2a0cffcba8ba1b0457da690b",
-    "git_hash": "493cfc0cc3894e8512720ee179f2020644ab53d3"
-  },
-  {
-    "version": "1.0.1-rc.44",
-    "container_hash": "49cfab0bcea687a7b8b4dbd5a80ab59643995a47c743fa3a0e4e3df6ae27d08e",
-    "git_hash": "5bc2a96e265f0a5fc9ef5984c6279cfe41fd651a"
-  },
-  {
-    "version": "1.0.1-rc.45",
-    "container_hash": "f741740134d19c84a97eaeea12207a35578be0261a619936c7ad498066314771",
-    "git_hash": "28f1093d086c8b5497e3f6f2d9db4016bb66d20f"
-  },
-  {
-    "version": "1.0.1-rc.46",
-    "container_hash": "ae25cb3ec2f89418370ebf03e402fa267f00d0a6030bc76dcfb973fc1a9c4c0b",
-    "git_hash": "3d1bcf7257405a7c96a78a03f6de2c470253202c"
-  },
-  {
-    "version": "1.0.1-rc.47",
-    "container_hash": "94529b2e23042e124ca8472cc25f893182adca3b49d0edc9a96d7e96d7085209",
-    "git_hash": "07024ecf0f684f9091d94ddaaaba68ad24e35497"
-  },
-  {
-    "version": "1.0.1-rc.48",
-    "container_hash": "abab2f2937b4df86bed0c8dfd81a43cd59b3c1de22757c9adca8a73fce53f591",
-    "git_hash": "82649e772f3764ab0ecf4a3876059b9d3e4af13f"
-  },
-  {
-    "version": "1.0.1-rc.49",
-    "container_hash": "56f4bfa5886ffd27ca592b8705145db7d65f6c83167e1332ece19b7f7b9d2131",
-    "git_hash": "e4d7515cb9c5cb6e9e770417f78ff8d95f903bd3"
-  },
-  {
-    "version": "1.0.1-rc.50",
-    "container_hash": "5090fa2da43233252eed6b22afe6015df1937cb8a06dba8ba19f42379cfe07bb",
-    "git_hash": "2c38dc67902145bf1f1317a7a5dd84d014f92694"
-  },
-  {
-    "version": "1.0.1-rc.51",
-    "container_hash": "518a1116a7df4362775d0b18d6e9893c83648ac33a672543e53b51ee86a80a78",
-    "git_hash": "b7aa63a67e7ebd796619cdf98f584a8f52e77410"
-  },
-  {
-    "version": "1.0.1-rc.52",
-    "container_hash": "40923ec73458f0b9bc0131ddec93ba6021342cd705d5fe79215e120e39bcd555",
-    "git_hash": "3977b0390d3c42e1a385973d01aafbc91441931c"
-  },
-  {
-    "version": "1.0.1-rc.53",
-    "container_hash": "0ebcbad49626a1dbfc781ede78061a19bd8d5ad6074de3a880862e6f5ab56e72",
-    "git_hash": "8e6b142448dc68cdf4ac727415821f152268cd73"
-  },
-  {
-    "version": "1.0.1-rc.54",
-    "container_hash": "a3dd62693f8f0055ee697f3fa4dc6be2e99a60aa7771975f89b3dd75e6856ec8",
-    "git_hash": "e6663f08f071a6505025afbac4a8e34798297fff"
-  },
-  {
-    "version": "1.0.1-rc.55",
-    "container_hash": "013fad49b228d315d159a9b07a0516bd0993733b9dbbc53a08acf9e7e596aa10",
-    "git_hash": "a43b4bc5ed0df094d5877aebf68bec22120b67b1"
-  },
-  {
-    "version": "1.0.1-rc.56",
-    "container_hash": "bea0490c3781994c267b0f156a5fcc8555fd2d0e6e5383d09ff9ca3f02d5c016",
-    "git_hash": "62becd93988294780ef01c6feceaeea6d4f23f16"
-  },
-  {
-    "version": "1.0.1-rc.57",
-    "container_hash": "eb1fbef7c60487225512f0ae43f258acd4ec4446b6773a96339b35ffef9ab34a",
-    "git_hash": "6cfa41de60d790d8699923d7b6982d9d9bdce40f"
-  },
-  {
-    "version": "1.0.1-rc.58",
-    "container_hash": "95b66b856c75502594b38c4cdb2d8cfb153e4be62fca1f5db25781a7188d29f6",
-    "git_hash": "f23134d76d49ca11d94f8ee7b1c4f1a72019234e"
-  },
-  {
-    "date": "2022-04-08",
-    "version": "pr-500-Rebuild-workflow",
-    "container_hash": "acb6af58b3b101f808b57deb36218d3165876a1910db3c175f77b18e20b0770c",
-    "git_hash": "b2afbe5fa0c4d2a281facafc85688ce5bd692559"
-  },
-  {
-    "date": "2022-04-14",
-    "version": "1.0.1-rc.59",
-    "container_hash": "5b21d21ee08586c0b560018c26cbc7cf36033b8978b32b2abf91be77bbebb7f4",
-    "git_hash": "6ec3dea832b362fc30059d2dce0bf7df49d8a0a3"
-  },
-  {
-    "date": "2022-04-14",
-    "version": "1.0.1-rc.60",
-    "container_hash": "c4fe7c4b9fd79f1317c7c6bebaebe62c384eeba3f3807c130e52fc71b4ffceec",
-    "git_hash": "2ce127a3a9f87bc0b517daac43136264d8543c97"
-  },
-  {
-    "date": "2022-04-14",
-    "version": "1.0.1-rc.61",
-    "container_hash": "17d193e430e2e5e6dbf5cf4856afb5c4df9d0330a6be34df8c2fc218ab14b79d",
-    "git_hash": "742fec429785b9615476da1c212462bb86ebaf28"
-  },
-  {
-    "date": "2022-04-14",
-    "version": "1.0.1-rc.62",
-    "container_hash": "e6c713fc2827f97df949f3f7b76e2ca5fc90279cea4a89239bb04243b4a83393",
-    "git_hash": "e1b6448b1298bc0884adfc4e6e122bc75128c27b"
-  },
-  {
-    "date": "2022-04-15",
-    "version": "1.0.1-rc.63",
-    "container_hash": "7842487206e0ca033e5422e277e2e035ac3b38bd43e7613850a96a7ff422cb4e",
-    "git_hash": "4272cb8cf0e179f00ccdc4012d68fc2b2f462ae2"
-  },
-  {
-    "date": "2022-04-18",
-    "version": "1.0.1-rc.64",
-    "container_hash": "81503d0fa6234d1d0ea54844bdd578c8e60b8fa5485890fac15d063639be5171",
-    "git_hash": "697f00daa07993ff619deb9f2c326bce73721619"
-  },
-  {
-    "date": "2022-04-21",
-    "version": "1.0.1-rc.65",
-    "container_hash": "598f20f9a0661338aca446a091821cdeb9682a47af99e4c656b6ff72a1a5d66c",
-    "git_hash": "9ebe1d9659bb698a909a97cbef642a5e77fafa9e"
-  },
-  {
-    "date": "2022-04-25",
-    "version": "1.0.1-rc.66",
-    "container_hash": "6572fbae69961a6c8d4bd624557516c702c8f73973c4d6075e4f876ed39e643f",
-    "git_hash": "6bfb0e0b2ef5d8955ab7d89f827826f67e00ac3d"
-  },
-  {
-    "date": "2022-04-28",
-    "version": "1.0.1-rc.67",
-    "container_hash": "46d864957e15f2baee4093fe134d13636d286455bdd10d217d33ce57946714db",
-    "git_hash": "4d75446dd51fec7d3e239ff4db897260b5a01617"
-  },
-  {
-    "date": "2022-05-02",
-    "version": "1.0.1-rc.68",
-    "container_hash": "eed8d1b508c1ebf98cc980a975304253ac02e381f21949bc5c524777af558ef9",
-    "git_hash": "00b09ba5e7a08672beab6e4aa8cc60a2fa35fafd"
-  },
-  {
-    "date": "2022-05-04",
-    "version": "1.0.1-rc.69",
-    "container_hash": "17fbe8ea4b791349a9c7a1786c54face9f244e53ede794463a6e8ced7bf39170",
-    "git_hash": "13c26275ad762c04960eda93dc7627e901c234be"
-  },
-  {
-    "date": "2022-05-06",
-    "version": "1.0.1-rc.610",
-    "container_hash": "23c5a258621e3db36eb05ef6e4c18b6434c8252bee15b8437fbe58425a67492b",
-    "git_hash": "0b6af984aea6de358ee6456b03eadffb919485a2"
-  },
-  {
-    "date": "2022-05-09",
-    "version": "1.0.1-rc.611",
-    "container_hash": "4717bc037e0f3ea7909a54ff2848916da98ef893e9f71079c74ec391826cecbc",
-    "git_hash": "311b28bbf5b3b87de1ce5bfa2248a674b99caf61"
-  },
-  {
     "date": "2022-05-09",
     "version": "1.1.0",
     "container_hash": "de59441da2a80281b7d00f92b2dc33c83d4d3f2259323502a2a278d36788fb09",
     "git_hash": "c6d79fd869a072d804e21edaf479bf71e41f5834"
-  },
-  {
-    "date": "2022-05-09",
-    "version": "1.1.1-rc",
-    "container_hash": "d681502012b88e14a500363e5b574c5e1de097b241c899c795986247bbe2f05e",
-    "git_hash": "29e181b3d053d4a10a01a6ac8234a6f39a1d72c4"
-  },
-  {
-    "date": "2022-05-09",
-    "version": "1.1.2-rc",
-    "container_hash": "e3cd22c4f604e711ad1a186b4f6449f69e8ec00aa60081d4e3f9feee13fc3eed",
-    "git_hash": "51d0462accb8bb2d0a449081211fa32b6efa32ec"
   },
   {
     "date": "2022-05-10",
@@ -913,88 +147,16 @@
     "git_hash": "c6d79fd869a072d804e21edaf479bf71e41f5834"
   },
   {
-    "date": "2022-05-16",
-    "version": "1.1.3-rc",
-    "container_hash": "aa79439ff486b6249a395c4d5a0a8bf4bf77f58b7aca5f83ac0d381398554358",
-    "git_hash": "b235291bf41784c7f10216e483f5e6f83ef9ac04"
-  },
-  {
     "date": "2022-05-17",
     "version": "1.1.0",
     "container_hash": "a8221eb4d63480d584745d5080ec67c657cabf99953dcba4bc76d4de0af10f34",
     "git_hash": "c6d79fd869a072d804e21edaf479bf71e41f5834"
   },
   {
-    "date": "2022-05-20",
-    "version": "1.1.5-rc",
-    "container_hash": "6d0b693995ed35ac99f7bc62a7c9de0a5a3f9c69724ad81c5347c850ce1f86c9",
-    "git_hash": "c76193900d86f91d2f290afffcfb2a2c154dd9d9"
-  },
-  {
-    "date": "2022-05-23",
-    "version": "1.1.6-rc",
-    "container_hash": "8311715b3948fba2722ae370a3c040572f7736cff525f89378db28ebf344b9db",
-    "git_hash": "2c45ce1841393d5dcbe92f3c4003290b3e9200fe"
-  },
-  {
-    "date": "2022-05-27",
-    "version": "1.1.7-rc",
-    "container_hash": "be63e1d2f1a14187f43e4d2f2f28a5c61836df7b9dcf10d0cc007cc71d6a7799",
-    "git_hash": "9b7e15c3a68b2ffa4d624ce30069469de92bc8ec"
-  },
-  {
-    "date": "2022-05-27",
-    "version": "1.1.8-rc",
-    "container_hash": "794321ee0b8c3b1924ed4e61b751edd5f7234f5d7b44c44630cc6adbb9ee4215",
-    "git_hash": "d5b1627ce25e3a394ad6802f0c896c16a74c23a8"
-  },
-  {
     "date": "2022-05-31",
     "version": "1.1.0",
     "container_hash": "7302f25efafc8c76d90ed43b741245fbd8da65014af427313b194598e7ef6766",
     "git_hash": "c6d79fd869a072d804e21edaf479bf71e41f5834"
-  },
-  {
-    "date": "2022-06-01",
-    "version": "1.1.9-rc.0",
-    "container_hash": "372b9e69cb8dd235a94edd764fab7802270b755f91feadbe703ef6e694637756",
-    "git_hash": "a139f5cbe20cffa9a92e7aa8d2a2649001e9e064"
-  },
-  {
-    "date": "2022-06-01",
-    "version": "1.1.1-rc.9",
-    "container_hash": "243d0e9b45d9b65b4ee3222470cc3c433398e0bafd70a27eb4e7ea789cb021f0",
-    "git_hash": "aa605a03f9df21c3a5924273e9cafe18e98ade96"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "1.1.1-rc.10",
-    "container_hash": "ce75d523044ea0052fe50817ba9af44f8db276f77c2b37bb0650245b00347ef8",
-    "git_hash": "c1defe8829bd16d6f3303b6024fc9c4047e55051"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "1.1.1-rc.11",
-    "container_hash": "87eb10e3f0301ffc6c1d11d53f776aae7a84eb69fba1e66dbd582c1a5ad30bfe",
-    "git_hash": "22613e2d836f9690f2155e9f50d7ea7cda350ebc"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "1.1.1-rc.12",
-    "container_hash": "ea82cb7c140cb4abd2c689a2e6cae226708e14dc1eab8ec6086ea86315b079a6",
-    "git_hash": "b256466e4eb01b094ed075ac0ceb9670051b22da"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "1.1.1-rc.13-amd64",
-    "container_hash": "76b5e27d5105d519fd8602cd9c8a423d7dc13c7f1dba48d635ad948beb24f0b4",
-    "git_hash": "7cf7a42b2d6c4614faf1cb72255ecdf56254abb4"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "1.1.1-rc.13-arm64",
-    "container_hash": "6687243c46835c2dbf342da47520f9207b0cc413f4d32c4a575fe9ae20588ee2",
-    "git_hash": "7cf7a42b2d6c4614faf1cb72255ecdf56254abb4"
   },
   {
     "date": "2022-06-03",
@@ -1007,18 +169,6 @@
     "version": "1.1.1-arm64",
     "container_hash": "1032f59b09e8a30a4a1bb0714d3d9c425c832bd9055eb8a7f2db605e7edea9af",
     "git_hash": "bb8fc3df52d442b63f5d1c7a225b0d0cbfa8ee08"
-  },
-  {
-    "date": "2022-06-06",
-    "version": "1.1.2-rc.0-amd64",
-    "container_hash": "86541a3a8a57e550c1424bd2a8a2a21379024b0e94de1ba465753df577e7d6a8",
-    "git_hash": "a7d3c7f3fc5124db8213190a11c51196ce9fae68"
-  },
-  {
-    "date": "2022-06-06",
-    "version": "1.1.2-rc.0-arm64",
-    "container_hash": "88b9640bd0e3b897a11407880732f47c65b3998e13ea56266bb09c5b0e590bd8",
-    "git_hash": "a7d3c7f3fc5124db8213190a11c51196ce9fae68"
   },
   {
     "date": "2022-06-07",
@@ -1039,30 +189,6 @@
     "git_hash": "bb8fc3df52d442b63f5d1c7a225b0d0cbfa8ee08"
   },
   {
-    "date": "2022-06-13",
-    "version": "1.1.2-rc.1-amd64",
-    "container_hash": "bc351ed677e765f8c5b57243da8b148eab466dc1147899ffd9d32f06afa892af",
-    "git_hash": "ff677b43098a3fcf262e1431d178425a88a51d7d"
-  },
-  {
-    "date": "2022-06-13",
-    "version": "1.1.2-rc.1-arm64",
-    "container_hash": "13319f968877ce8cd9d65889a2109bebc910d03babcb6ef393e6b45fb510020c",
-    "git_hash": "ff677b43098a3fcf262e1431d178425a88a51d7d"
-  },
-  {
-    "date": "2022-06-13",
-    "version": "1.1.2-rc.2-arm64",
-    "container_hash": "41f9db854ba9daf7a47d319f11b45816618695458bf6894238a54e63ba26e15d",
-    "git_hash": "f3f80687808d532ba9cf82aed161c6a43e050ced"
-  },
-  {
-    "date": "2022-06-13",
-    "version": "1.1.2-rc.2-amd64",
-    "container_hash": "d8e754f13c74f2cb20c9d199dadc45203c51c99046e9d3b2c3fdecd464d706c0",
-    "git_hash": "f3f80687808d532ba9cf82aed161c6a43e050ced"
-  },
-  {
     "date": "2022-06-14",
     "version": "1.1.1-arm64",
     "container_hash": "fadf6a55f2c1d777404e1bd059b5dd6114916226eda38d70ac542b31ac77a10a",
@@ -1081,70 +207,10 @@
     "git_hash": "c6d79fd869a072d804e21edaf479bf71e41f5834"
   },
   {
-    "date": "2022-06-16",
-    "version": "1.1.2-rc.3-arm64",
-    "container_hash": "615be0e7634d7fd44501081c2b60f88e578c92c005930f08d7699941b4ded239",
-    "git_hash": "c126e2ab00afdd54642b7c99c06012763c288c70"
-  },
-  {
-    "date": "2022-06-16",
-    "version": "1.1.2-rc.3-amd64",
-    "container_hash": "8526142d0040adef517ada04890b3cbd3c1561bcf787e6c4306a848f121a503d",
-    "git_hash": "c126e2ab00afdd54642b7c99c06012763c288c70"
-  },
-  {
-    "date": "2022-06-17",
-    "version": "1.1.2-rc.4-arm64",
-    "container_hash": "db2588d773c941c0cb5bcc4cb0f543f2b8a52ddb9a955b18a41b3370ae389ec6",
-    "git_hash": "13e62bfce0b5b989f023b57dd9c832ab2e3da83f"
-  },
-  {
-    "date": "2022-06-17",
-    "version": "1.1.2-rc.4-amd64",
-    "container_hash": "207a96552981adef4e090848cb49fa394f77cebbe3e36b7a83c321cfeee51603",
-    "git_hash": "13e62bfce0b5b989f023b57dd9c832ab2e3da83f"
-  },
-  {
-    "date": "2022-06-20",
-    "version": "1.1.2-rc.5-arm64",
-    "container_hash": "9803341d23920823ac6f88ae587bf9f3665896a6eaf976865f0c78fd10cf0f71",
-    "git_hash": "e26c759834661aa709a1a7f921839880408b3488"
-  },
-  {
-    "date": "2022-06-20",
-    "version": "1.1.2-rc.5-amd64",
-    "container_hash": "81d143b3bf8e2e4dd58ee2e3a545f5bc5f3ec1e71eb336a70c4f9edbf02941c5",
-    "git_hash": "e26c759834661aa709a1a7f921839880408b3488"
-  },
-  {
     "date": "2022-06-21",
     "version": "1.1.0",
     "container_hash": "af6d7250126df4f2d218ad17b115df47f69d68da2b22786030fe11782e77fc51",
     "git_hash": "c6d79fd869a072d804e21edaf479bf71e41f5834"
-  },
-  {
-    "date": "2022-06-22",
-    "version": "1.1.2-rc.6-arm64",
-    "container_hash": "e8055ddedc86a86dd37d044ffa3d11671e2143b198f8892b7167ce6b79ed7f28",
-    "git_hash": "7db183c09b88d2c1acbaa64091687212ab21e5a9"
-  },
-  {
-    "date": "2022-06-22",
-    "version": "1.1.2-rc.6-amd64",
-    "container_hash": "7022e3e353db61ae3f036416564bd1ccad092d8c12710c06364dd04bb04a06fc",
-    "git_hash": "7db183c09b88d2c1acbaa64091687212ab21e5a9"
-  },
-  {
-    "date": "2022-06-22",
-    "version": "1.1.2-rc.7-arm64",
-    "container_hash": "5ba87b9a5b8c84228d4691329d9f03d69ce2def9dfd56e599d023931f18d6dc6",
-    "git_hash": "a88ce204ec03784cf47c92b49ce203020afc60cf"
-  },
-  {
-    "date": "2022-06-22",
-    "version": "1.1.2-rc.7-amd64",
-    "container_hash": "4f205375d6dae124ceec776c36eeb145cea28cc74ced60079292e2fe9e69df69",
-    "git_hash": "a88ce204ec03784cf47c92b49ce203020afc60cf"
   },
   {
     "date": "2022-06-22",
@@ -1157,30 +223,6 @@
     "version": "1.1.2-amd64",
     "container_hash": "f6ef4f262f83133f40821cab0f548f59a8594bd19ce0dccf337c817042655ae7",
     "git_hash": "59e2ca58549fe43ef83bf90d8266792bac2ba532"
-  },
-  {
-    "date": "2022-06-23",
-    "version": "1.1.3-rc.0-arm64",
-    "container_hash": "a5c0b24ed0d7b5a2779a8dfe618648a316e33ca365021d54d7e751d94371ef06",
-    "git_hash": "86285047ea02637e3241a2fe936c3b03739eb8c4"
-  },
-  {
-    "date": "2022-06-23",
-    "version": "1.1.3-rc.0-amd64",
-    "container_hash": "fa05d795a710e7ecef1dc566bbd07c44d1daf484bbb48f772101fc5a74c73ae7",
-    "git_hash": "86285047ea02637e3241a2fe936c3b03739eb8c4"
-  },
-  {
-    "date": "2022-06-23",
-    "version": "1.1.3-rc.1-arm64",
-    "container_hash": "a79dcfd160b437cf4434907ced97c4a062c2cb560b4c920a3fa2801e944e1128",
-    "git_hash": "32416490cd850c36f35bae74d211b6122744acbe"
-  },
-  {
-    "date": "2022-06-23",
-    "version": "1.1.3-rc.1-amd64",
-    "container_hash": "eaf7d3011afd73d85eea96124a126bf286da2b52d820ce47ed69e54e7790571f",
-    "git_hash": "32416490cd850c36f35bae74d211b6122744acbe"
   },
   {
     "date": "2022-06-28",
@@ -1202,63 +244,15 @@
   },
   {
     "date": "2022-06-30",
-    "version": "1.1.3-rc.2-arm64",
-    "container_hash": "ead7e781fd3409874d540e7ff341a203a31c0d2450098f9cec970a92ec283443",
-    "git_hash": "2c909a92cbfe9faa77a41cc478fc4dd0fe40d347"
-  },
-  {
-    "date": "2022-06-30",
     "version": "1.1.3-arm64",
     "container_hash": "5835fc355e0f56f6bcbe486f4d696fa4b09158dbdbc53ddb43ed3103fe327f3b",
     "git_hash": "35637e0533bfb283f271f18d02faf09d983c410d"
   },
   {
     "date": "2022-06-30",
-    "version": "1.1.3-rc.2-amd64",
-    "container_hash": "04bfe09bb22393333a86b5623313da9a6d899a3a41f5a5ae1c62017219cb3897",
-    "git_hash": "2c909a92cbfe9faa77a41cc478fc4dd0fe40d347"
-  },
-  {
-    "date": "2022-06-30",
     "version": "1.1.3-amd64",
     "container_hash": "0c76dce0f70ed4791cd0f51df9a1b49b47bc7558bd390b7fc340ff9681a33b9f",
     "git_hash": "35637e0533bfb283f271f18d02faf09d983c410d"
-  },
-  {
-    "date": "2022-06-30",
-    "version": "1.1.4-rc.0-arm64",
-    "container_hash": "0c5e70f7d3d8a3957fca42c503894ac03114515927d77cb45bb905c69545de9e",
-    "git_hash": "1853e09d50ecd6305e9221a6b0755950610b4826"
-  },
-  {
-    "date": "2022-06-30",
-    "version": "1.1.4-rc.0-amd64",
-    "container_hash": "71846772b70fd7e1224e2119fde8b723c69749747b648b72ae656176f96df9f6",
-    "git_hash": "1853e09d50ecd6305e9221a6b0755950610b4826"
-  },
-  {
-    "date": "2022-06-30",
-    "version": "1.1.4-rc.1-arm64",
-    "container_hash": "d016cd28372e7959cdde49f7bb5a82df309888b9567db77196891f67a8a34498",
-    "git_hash": "0f027a1d33052068e98ecb84de8cb862bb70925a"
-  },
-  {
-    "date": "2022-06-30",
-    "version": "1.1.4-rc.1-amd64",
-    "container_hash": "c1b103ad14d2179b98540aab4f2baf019963bded80e925b5d104b70686b0142a",
-    "git_hash": "0f027a1d33052068e98ecb84de8cb862bb70925a"
-  },
-  {
-    "date": "2022-07-04",
-    "version": "1.1.4-rc.2-arm64",
-    "container_hash": "83821a9edc44dbe83616b90e955a25c3f9b54a8953bd2c25a0703d662a747019",
-    "git_hash": "cf528d4492204c0fbb2db8dd317e7fb4977dab23"
-  },
-  {
-    "date": "2022-07-04",
-    "version": "1.1.4-rc.2-amd64",
-    "container_hash": "6ddfcbcd2cc6209d833f20acbe0ef5521ce0ce81101df547d715b7e2c4fe95e5",
-    "git_hash": "cf528d4492204c0fbb2db8dd317e7fb4977dab23"
   },
   {
     "date": "2022-07-05",
@@ -1303,30 +297,6 @@
     "git_hash": "35637e0533bfb283f271f18d02faf09d983c410d"
   },
   {
-    "date": "2022-07-07",
-    "version": "1.1.4-rc.3-arm64",
-    "container_hash": "481caa4365f1b886b586a02b388d4c27fa47c32d3835d359280ecb69874c5b92",
-    "git_hash": "c893993a1d98e9e928e2569383067be034b1aed6"
-  },
-  {
-    "date": "2022-07-07",
-    "version": "1.1.4-rc.3-amd64",
-    "container_hash": "f44c3c8b7600805c0e7ed814bfba4794fb01a1e9bbff1558dd1d22f7ae13bac0",
-    "git_hash": "c893993a1d98e9e928e2569383067be034b1aed6"
-  },
-  {
-    "date": "2022-07-11",
-    "version": "1.1.4-rc.4-amd64",
-    "container_hash": "054cd29823d354b1b59977502eac9c971a108f3e17f993a2a950c14cd75c1b84",
-    "git_hash": "2a5d29d764f95c9e7bc7b811214adf44dd278732"
-  },
-  {
-    "date": "2022-07-11",
-    "version": "1.1.4-rc.4-arm64",
-    "container_hash": "da1032579574cef24159930e55ce1d7f60cd2ecc5ad8b1b8474b29579873bc06",
-    "git_hash": "2a5d29d764f95c9e7bc7b811214adf44dd278732"
-  },
-  {
     "date": "2022-07-12",
     "version": "1.1.2-arm64",
     "container_hash": "1d32db37a006f6ef0d586326a87d3e4df01e5bd24c92a440f57846672f658be4",
@@ -1367,30 +337,6 @@
     "version": "1.1.2-amd64",
     "container_hash": "4da93ce95b44e13f2f7e08e7503aa51571287dd8d4811cdaa56581d72e60b575",
     "git_hash": "59e2ca58549fe43ef83bf90d8266792bac2ba532"
-  },
-  {
-    "date": "2022-07-14",
-    "version": "1.1.4-rc.5-arm64",
-    "container_hash": "377355a5dc5f9ec1bf7a846428bfb29e1477cdf881702c508bc13ab4e409b336",
-    "git_hash": "7fc4a2c56a90f144334183ee829913019ba5b72a"
-  },
-  {
-    "date": "2022-07-14",
-    "version": "1.1.4-rc.5-amd64",
-    "container_hash": "41dcf22939a6d49f7fa47341a30f9e2a4469ade6c04e3f9e593a0a728136d60a",
-    "git_hash": "7fc4a2c56a90f144334183ee829913019ba5b72a"
-  },
-  {
-    "date": "2022-07-15",
-    "version": "1.1.4-rc.6-arm64",
-    "container_hash": "d61d37a13f3feb97ca40ac07622943448f624045ff583925e769df4491f5a822",
-    "git_hash": "fd973b0006c3ae722df0eab1f4ef8f6ca58b2ba6"
-  },
-  {
-    "date": "2022-07-15",
-    "version": "1.1.4-rc.6-amd64",
-    "container_hash": "2d25c33590552f71a7179b10a01160a65616aa47194e7407cd5af6209529895a",
-    "git_hash": "fd973b0006c3ae722df0eab1f4ef8f6ca58b2ba6"
   },
   {
     "date": "2022-07-19",
@@ -1471,30 +417,6 @@
     "git_hash": "d9eba3dc7af57b6ea650637e4362978299806c4e"
   },
   {
-    "date": "2022-07-21",
-    "version": "1.1.4-rc.7-arm64",
-    "container_hash": "e00747e13e20dc176551520295dfc1285ff1eb048e0b0bca1859630900adcfbb",
-    "git_hash": "18b1f097d34ce2b3a599bf837d76e47ac7feab80"
-  },
-  {
-    "date": "2022-07-21",
-    "version": "1.1.4-rc.7-amd64",
-    "container_hash": "6ee3b28113449e266cab22fd9966fe2b567019581e2b83371001ec4286d9ea56",
-    "git_hash": "18b1f097d34ce2b3a599bf837d76e47ac7feab80"
-  },
-  {
-    "date": "2022-07-22",
-    "version": "1.1.4-rc.8-arm64",
-    "container_hash": "a09eba4fac43211edb6b1822c49fab26b0e5edd8973c1576f25a8cb29b0ff86d",
-    "git_hash": "88650cb1550af4cd3f0d0e20ce6c6133c0727a34"
-  },
-  {
-    "date": "2022-07-22",
-    "version": "1.1.4-rc.8-amd64",
-    "container_hash": "374297b2d57038d64e527c7fc63cab49854fa85ea6f3ce35189b845681019e15",
-    "git_hash": "88650cb1550af4cd3f0d0e20ce6c6133c0727a34"
-  },
-  {
     "date": "2022-07-26",
     "version": "1.1.2-arm64",
     "container_hash": "76c8b54c8584948945c0cc98f5d4acb0f2dc751dc49de22c95db9e2f1e0b59f6",
@@ -1535,18 +457,6 @@
     "version": "1.1.0",
     "container_hash": "33008df5b33f8ceb80ee10b806af522c66d2063d9e2bed967181e89bac57891b",
     "git_hash": "c6d79fd869a072d804e21edaf479bf71e41f5834"
-  },
-  {
-    "date": "2022-07-28",
-    "version": "1.1.4-rc.9-arm64",
-    "container_hash": "c063ba2f199d158d96779a8bcbf677ef145db14300adeaa4058c41efcddeb450",
-    "git_hash": "02991d94f5e728a47d550543f7d0d9f65ae8bb32"
-  },
-  {
-    "date": "2022-07-28",
-    "version": "1.1.4-rc.9-amd64",
-    "container_hash": "b70e4feefab97e3e56ac12f6e3f76abf7fbeaf1780abc176b1d5bb633fa3f985",
-    "git_hash": "02991d94f5e728a47d550543f7d0d9f65ae8bb32"
   },
   {
     "date": "2022-08-02",
@@ -1591,18 +501,6 @@
     "git_hash": "23c20c91d2579b179cb80a4c1824fad78f638a44"
   },
   {
-    "date": "2022-08-02",
-    "version": "1.1.4-rc.10-arm64",
-    "container_hash": "9a58bee9a2123fdeabcfe1141578079a4ae0f091374d5bb6c065e0eb2614fd56",
-    "git_hash": "a0ccabc3d8cd0bdf042fa877ce4d524c9466c7e3"
-  },
-  {
-    "date": "2022-08-02",
-    "version": "1.1.4-rc.10-amd64",
-    "container_hash": "1ede3147b01341a4197d808b0665ceb3df27ef099750a22cdce94a6aa88bbf86",
-    "git_hash": "a0ccabc3d8cd0bdf042fa877ce4d524c9466c7e3"
-  },
-  {
     "date": "2022-08-03",
     "version": "2.0.0.beta.3-arm64",
     "container_hash": "1c2f85934e01b921e1314b09c91bfeb4151e52f7a0c6cdca263fb484bbc20f20",
@@ -1613,90 +511,6 @@
     "version": "2.0.0.beta.3-amd64",
     "container_hash": "2a11f32c4d23f9871d7fd0ee642576e17b7526c6436994e545eb3f1007aaefd5",
     "git_hash": "e49964e30110b75033bf1cd05843e66318576800"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "1.1.4-rc.11-arm64",
-    "container_hash": "b672279a6acb49b290be54ea760d04f89ea77cff64bb05313c72d7e21af40e8b",
-    "git_hash": "8bc683239f2cbb724dc49c0af8550bf6d9a734e4"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "1.1.4-rc.12-arm64",
-    "container_hash": "f965208cbd4cffbac2fe34e5f48eb58637b813233e5f64b956c359a8fb430a08",
-    "git_hash": "3d50a0fb09ff55f61b1b2f82b898515abbe8f59d"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "1.1.4-rc.11-amd64",
-    "container_hash": "74836165c5cfa13c457914b35048bf179931ef7036816c50a6b4736e0d2d7e8f",
-    "git_hash": "8bc683239f2cbb724dc49c0af8550bf6d9a734e4"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "1.1.4-rc.13-arm64",
-    "container_hash": "54eeb73354318c10488cc6e03500445b4e5fcbf1346f0c99b50f2569fad251b2",
-    "git_hash": "3a4147daabe36a92f074367a49d5d4e304cc132a"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "1.1.4-rc.12-amd64",
-    "container_hash": "679ef832f55d44c279b51133fadf8c4efe89fd07dd8627471127e0aed580c3dc",
-    "git_hash": "3d50a0fb09ff55f61b1b2f82b898515abbe8f59d"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "1.1.4-rc.13-amd64",
-    "container_hash": "bb2c8f65563c2f7e99bc9f1a4651075fbbb6aab33273ed765b79039e92c8240f",
-    "git_hash": "3a4147daabe36a92f074367a49d5d4e304cc132a"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "1.1.4-rc.14-arm64",
-    "container_hash": "0e20fd147208c2bccb6f261b1fcb9200e026d95220c300b202aaa761e2bbac33",
-    "git_hash": "1dd11ccb432749ea349576aab9eab057f9414563"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "1.1.4-rc.14-amd64",
-    "container_hash": "3dd5a8be10bf3838e6b35bedfebaa6eb3eeda9452543bad5dafe76af08280aab",
-    "git_hash": "1dd11ccb432749ea349576aab9eab057f9414563"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "1.1.4-rc.15-arm64",
-    "container_hash": "ceef231d30c7c93b5dfc34f12afa19f3e900b0015af24de5b0995b03d38ec2b6",
-    "git_hash": "601f62ea96e848cdc537cd9874e2608da72409d5"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "1.1.4-rc.15-amd64",
-    "container_hash": "a56c97a1333fbb8523c34e24fdc14ece4b6655f76990f5de37ea92a23a73a798",
-    "git_hash": "601f62ea96e848cdc537cd9874e2608da72409d5"
-  },
-  {
-    "date": "2022-08-08",
-    "version": "1.1.4-rc.16-arm64",
-    "container_hash": "986b50053c49fffb28adb7a7862ce185154fc5a3b9b5b448b80039ff981d1937",
-    "git_hash": "bb846533546d8fd014aac4c1a5f87568a259e905"
-  },
-  {
-    "date": "2022-08-08",
-    "version": "1.1.4-rc.16-amd64",
-    "container_hash": "6a2e7879f436a1a1dd5e8850c856caf9a0a8d374a7de98a22057ea9a621d65af",
-    "git_hash": "bb846533546d8fd014aac4c1a5f87568a259e905"
-  },
-  {
-    "date": "2022-08-08",
-    "version": "2.0.0-beta.4-arm64",
-    "container_hash": "c2bb5cf12823ba47266ea41e66dc8ea23407aebc456e3006f2634f1a4b43939b",
-    "git_hash": "31853e9774fcd30d67916f20042ef3a027380a59"
-  },
-  {
-    "date": "2022-08-08",
-    "version": "2.0.0-beta.4-amd64",
-    "container_hash": "8ade8613c3d0a9d0726989d9cf5503303d16937c381ea86048cc19438808947b",
-    "git_hash": "31853e9774fcd30d67916f20042ef3a027380a59"
   },
   {
     "date": "2022-08-09",
@@ -1741,72 +555,6 @@
     "git_hash": "23c20c91d2579b179cb80a4c1824fad78f638a44"
   },
   {
-    "date": "2022-08-10",
-    "version": "1.1.4-rc.17-arm64",
-    "container_hash": "ddb157457545ac2126539a80e73be2f545b11671317219529c7686fb5611d8b5",
-    "git_hash": "fbad851d9a443de3d687604cdf06eef7d88075d4"
-  },
-  {
-    "date": "2022-08-10",
-    "version": "1.1.4-rc.17-amd64",
-    "container_hash": "41da1bd0c51c4e56c38b426070decf53e63b6d0ec706c380eb840ed42a99cc17",
-    "git_hash": "fbad851d9a443de3d687604cdf06eef7d88075d4"
-  },
-  {
-    "date": "2022-08-11",
-    "version": "1.1.4-rc.18-arm64",
-    "container_hash": "09022325a429bfbb0c147afc4fff918b82b16deaae17a17f0cc6babf91a16ba9",
-    "git_hash": "a0efaaec168f0ad92912c1304927e0dec9984c62"
-  },
-  {
-    "date": "2022-08-11",
-    "version": "1.1.4-rc.18-amd64",
-    "container_hash": "952861990bd92532c3482477137931f741152daf4b9f02e587f5cb181685aa7a",
-    "git_hash": "a0efaaec168f0ad92912c1304927e0dec9984c62"
-  },
-  {
-    "date": "2022-08-11",
-    "version": "1.1.4-rc.19-amd64",
-    "container_hash": "35d911014ddefeb1cd31f11b209d559db55aa763b4474cea26658df99a9ca96b",
-    "git_hash": "a8623164816acb3020b73c4115c182a13e8a3c25"
-  },
-  {
-    "date": "2022-08-11",
-    "version": "1.1.4-rc.19-arm64",
-    "container_hash": "1ff08e89baa0ce83a6b15b0009f4ad82e4f96585068eea936b076303305e160b",
-    "git_hash": "a8623164816acb3020b73c4115c182a13e8a3c25"
-  },
-  {
-    "date": "2022-08-15",
-    "version": "1.1.4-rc.20-amd64",
-    "container_hash": "48ce0b8ab6cd4c0e6ec43b51cae76e812d4e730c997bbeca1d4dd6af8d595721",
-    "git_hash": "2a8cb22c5fd3d41c00d68c0ccdd98a72c6140a2f"
-  },
-  {
-    "date": "2022-08-15",
-    "version": "2.0.0-beta.5-arm64",
-    "container_hash": "60733185151f7edece88fee8feaf31cbc958b085458bd2e36a6a5aebdfc6d598",
-    "git_hash": "23c6b16f4a6f8f456b829be64761596d004a2f47"
-  },
-  {
-    "date": "2022-08-15",
-    "version": "2.0.0-beta.5-amd64",
-    "container_hash": "6d7a6a54a292783914886c551a21cd48306b8dae1ca6ac7957e1174e30177f52",
-    "git_hash": "23c6b16f4a6f8f456b829be64761596d004a2f47"
-  },
-  {
-    "date": "2022-08-15",
-    "version": "1.1.4-rc.21-arm64",
-    "container_hash": "43b3dbd548beaa0f91f326ac5dde781ae3192a6dbb23832513fbb749c0f41c10",
-    "git_hash": "9161b848e61c6f62d822fa18ca2087b3f2fd4c4d"
-  },
-  {
-    "date": "2022-08-15",
-    "version": "1.1.4-rc.21-amd64",
-    "container_hash": "994a3a78712aa26687c82ab0d9f65e7e1cf5e721f87ed8d03090ed8892e0c168",
-    "git_hash": "9161b848e61c6f62d822fa18ca2087b3f2fd4c4d"
-  },
-  {
     "date": "2022-08-16",
     "version": "1.1.3-arm64",
     "container_hash": "a1c43f287cff0a1e1abd6888867122a7087809da32fa1e540cd97d58f27a9ff4",
@@ -1847,42 +595,6 @@
     "version": "1.1.1-amd64",
     "container_hash": "48fb82f8ee8e327976ffe482c7853c6b8217e2f9c5c5bbc8a5f470278ed098f9",
     "git_hash": "d9eba3dc7af57b6ea650637e4362978299806c4e"
-  },
-  {
-    "date": "2022-08-16",
-    "version": "1.1.4-rc.22-arm64",
-    "container_hash": "fdcff65c8527c6c2714a01fdf239c5862228c0c3ffeafa744b1d128e6bf6f8b2",
-    "git_hash": "fc5e6175844c8d1b9be6f9c0662e2855eb4017bd"
-  },
-  {
-    "date": "2022-08-16",
-    "version": "1.1.4-rc.22-amd64",
-    "container_hash": "1d01c2206eac691be95303b1cbc0c2f108f8e9f04e4af98b9a99f5209b5912e3",
-    "git_hash": "fc5e6175844c8d1b9be6f9c0662e2855eb4017bd"
-  },
-  {
-    "date": "2022-08-18",
-    "version": "2.0.0-beta.6-arm64",
-    "container_hash": "0858c88107e712ec8b9da7a96d989d0bc413094362b8c13e16c7cc0880399d3b",
-    "git_hash": "a6f2938d205e416f812d733b5196319a5a2f8ecd"
-  },
-  {
-    "date": "2022-08-19",
-    "version": "2.0.0-beta.6-amd64",
-    "container_hash": "90f861ab0b4f39439fa30772cc5aa410bd6b5fa3d263a1f169a1c66ce12240b7",
-    "git_hash": "a6f2938d205e416f812d733b5196319a5a2f8ecd"
-  },
-  {
-    "date": "2022-08-19",
-    "version": "1.1.4-rc.23-arm64",
-    "container_hash": "976a4b8bbce6542ddc52555bcc4f0aa984160a2655c609b9eb10b655d9598236",
-    "git_hash": "9f5513cffadfd31204f8a6336085f5da2cc45b65"
-  },
-  {
-    "date": "2022-08-19",
-    "version": "1.1.4-rc.23-amd64",
-    "container_hash": "a2efd5fd9c1a2f77ca3e1b818d760781c64b51ba65cedbed659f79b55b0f884f",
-    "git_hash": "9f5513cffadfd31204f8a6336085f5da2cc45b65"
   },
   {
     "date": "2022-08-23",
@@ -1927,42 +639,6 @@
     "git_hash": "23c20c91d2579b179cb80a4c1824fad78f638a44"
   },
   {
-    "date": "2022-08-25",
-    "version": "1.1.4-rc.24-arm64",
-    "container_hash": "7346c3b00fd8e97359085459de8e36586dc5864066a35a346be7c6a93814a593",
-    "git_hash": "0dcb7189df6067beb32ccd9ef404102eb3ac16b5"
-  },
-  {
-    "date": "2022-08-25",
-    "version": "1.1.4-rc.24-amd64",
-    "container_hash": "fd3b88906373405b75eabbefdea1645a8bbe7569aca687230104d8a348273186",
-    "git_hash": "0dcb7189df6067beb32ccd9ef404102eb3ac16b5"
-  },
-  {
-    "date": "2022-08-25",
-    "version": "1.1.4-rc.25-arm64",
-    "container_hash": "e09adb7a0416901c040087cd5b72edf0507c80938c12119f5d10e461cf4bd800",
-    "git_hash": "b3dbae136db0f55885834d488cd2330d4fdf3720"
-  },
-  {
-    "date": "2022-08-26",
-    "version": "1.1.4-rc.25-amd64",
-    "container_hash": "405c756ef9851e8eb0ec9a965c4e8c7b7959609251b79853cc585f583cd1b10b",
-    "git_hash": "b3dbae136db0f55885834d488cd2330d4fdf3720"
-  },
-  {
-    "date": "2022-08-26",
-    "version": "1.1.4-rc.26-arm64",
-    "container_hash": "521bd5cf217463deecdc794ec618c1012bfb9f11ee7fe011554bed51a94eb978",
-    "git_hash": "07cb945bc2a9fddc834b463a76f2aedbec720cd0"
-  },
-  {
-    "date": "2022-08-26",
-    "version": "1.1.4-rc.26-amd64",
-    "container_hash": "a767eb41306eba245cd2df7f00e93bfeafbdbe2b7162a56ced2eb58a218dcec5",
-    "git_hash": "07cb945bc2a9fddc834b463a76f2aedbec720cd0"
-  },
-  {
     "date": "2022-08-30",
     "version": "1.1.3-arm64",
     "container_hash": "c59168dd580b90f62e0bddab38169bf73deabaa2a0121de2ab5e60f618fb42e0",
@@ -2003,30 +679,6 @@
     "version": "1.1.3-amd64",
     "container_hash": "7a9d4b55fa2e4cc3bccc609ee46a27b2603a7aff57cae2daf6246031501c85e2",
     "git_hash": "b39f7704f51a0a38c4cd1dc3aea886291dc1e054"
-  },
-  {
-    "date": "2022-08-30",
-    "version": "1.1.4-rc.27-arm64",
-    "container_hash": "e0fa224610bda207e3ee04a44d74eb88ac63867d2a6e57c2ff901691e47b84de",
-    "git_hash": "9704d9159bf96fea868ea632afda2973c7e5283d"
-  },
-  {
-    "date": "2022-08-30",
-    "version": "1.1.4-rc.27-amd64",
-    "container_hash": "ef1b6c9012fc7829793e73f9afa3afec9d2682e4a6f3495ea9400c92ed1fba90",
-    "git_hash": "9704d9159bf96fea868ea632afda2973c7e5283d"
-  },
-  {
-    "date": "2022-09-02",
-    "version": "1.1.4-rc.28-amd64",
-    "container_hash": "36580ed479fcc3dbdb760d3abd2170c434b5c6f4a8e59226cd231818df91c00f",
-    "git_hash": "44661285c252221f23008fc4a95cc5ae49afd2c8"
-  },
-  {
-    "date": "2022-09-02",
-    "version": "1.1.4-rc.28-arm64",
-    "container_hash": "5969ab8ebafeec7ce556bd742e466c5ff88ee9fb682b4a588a36a868cab80e5b",
-    "git_hash": "44661285c252221f23008fc4a95cc5ae49afd2c8"
   },
   {
     "date": "2022-09-06",
@@ -2071,90 +723,6 @@
     "git_hash": "23c20c91d2579b179cb80a4c1824fad78f638a44"
   },
   {
-    "date": "2022-09-07",
-    "version": "1.1.4-rc.29-arm64",
-    "container_hash": "6a62ad945f59f679e7f9cbb214ea66f3ab4368a395d3399153732056581c4524",
-    "git_hash": "c4bdf992ef09f022a65d9878e9b5ff27e593da01"
-  },
-  {
-    "date": "2022-09-07",
-    "version": "1.1.4-rc.29-amd64",
-    "container_hash": "8d5264eeae8a9382df00efbe11be7d50ebf89b4fe97042055ffb5aaed132968f",
-    "git_hash": "c4bdf992ef09f022a65d9878e9b5ff27e593da01"
-  },
-  {
-    "date": "2022-09-08",
-    "version": "1.1.4-rc.30-arm64",
-    "container_hash": "2e79d836d7503d9016782cd6502e76ad9e67d891b55f2e0955a8d0c4f4a992b6",
-    "git_hash": "0513ba2c00133963a9782e2327968cb3300f88e6"
-  },
-  {
-    "date": "2022-09-08",
-    "version": "1.1.4-rc.30-amd64",
-    "container_hash": "0f8c92e3f3497dae8d3fa87c31607761b6ce93cfe16e6c5809987417201010c7",
-    "git_hash": "0513ba2c00133963a9782e2327968cb3300f88e6"
-  },
-  {
-    "date": "2022-09-09",
-    "version": "1.1.4-rc.31-amd64",
-    "container_hash": "8f10fe339b85aef1c8fad4a4a739185f431c7265d849a9aa7ce38ce39ef91966",
-    "git_hash": "eefcfceda9b462800dffdf92899a6dbe8f889b83"
-  },
-  {
-    "date": "2022-09-08",
-    "version": "1.1.4-rc.31-arm64",
-    "container_hash": "4be1cee6db4196ce8ec32f9aeb75c92db0812cec2664afded9b6220a0c684065",
-    "git_hash": "eefcfceda9b462800dffdf92899a6dbe8f889b83"
-  },
-  {
-    "date": "2022-09-08",
-    "version": "1.1.4-rc.32-arm64",
-    "container_hash": "6fefcb082f6ffca93bcb7bd6125e072304bbca0bdc556adafee365baa97bcc3b",
-    "git_hash": "0e3eb4a3ce70f35e88a3001e0c8e9b02c8250529"
-  },
-  {
-    "date": "2022-09-09",
-    "version": "1.1.4-rc.32-amd64",
-    "container_hash": "cbc8948865872e718fc55f8067666f0ad1a9cde2990b19d95013a4fa23a5b7fb",
-    "git_hash": "0e3eb4a3ce70f35e88a3001e0c8e9b02c8250529"
-  },
-  {
-    "date": "2022-09-09",
-    "version": "1.1.4-rc.33-arm64",
-    "container_hash": "b6da27f558bb6522122ad05f4b9172c4a2b2d3d4df3c1af2516cb2f09db93bd3",
-    "git_hash": "2e1d5391999b0ecceb95e721e081262ff4f1a578"
-  },
-  {
-    "date": "2022-09-09",
-    "version": "1.1.4-rc.33-amd64",
-    "container_hash": "43957475fef2ee6948f196e2c190e89e53f35e209061c808922c94d6f8b94221",
-    "git_hash": "2e1d5391999b0ecceb95e721e081262ff4f1a578"
-  },
-  {
-    "date": "2022-09-09",
-    "version": "2.0.0-beta.7-arm64",
-    "container_hash": "b068d966532b9c759d28e47a90f855b7401ba8b2c315a05bd6a7dc8b77ae0ccd",
-    "git_hash": "497ba5e53b7c35919428ad468e0c2019f0526f57"
-  },
-  {
-    "date": "2022-09-09",
-    "version": "2.0.0-beta.7-amd64",
-    "container_hash": "25d77b05c295fc4736a2613d6ec428f0cab9cde74bbcddd35a683c383bcc8c4c",
-    "git_hash": "497ba5e53b7c35919428ad468e0c2019f0526f57"
-  },
-  {
-    "date": "2022-09-12",
-    "version": "1.1.4-rc.34-amd64",
-    "container_hash": "a32f196a6cc01c344cbe59b2524e0a7cb61bbb2050552c051acff6f7846ad224",
-    "git_hash": "cd0fbab5856b0ab2951980aa58fa02ba89c92db0"
-  },
-  {
-    "date": "2022-09-12",
-    "version": "1.1.4-rc.34-arm64",
-    "container_hash": "1e82f321d39c974737d352d38aa8f2eecdba1e65ec407b3fad641e5700e1e083",
-    "git_hash": "cd0fbab5856b0ab2951980aa58fa02ba89c92db0"
-  },
-  {
     "date": "2022-09-13",
     "version": "1.1.3-arm64",
     "container_hash": "dd146b2dab2d2b34ac999840c9d1d166903b269aa16a60efb3ea5bf30f80cc0c",
@@ -2195,54 +763,6 @@
     "version": "1.1.1-amd64",
     "container_hash": "6352e13f47736c32069259669277174efa5a993db88da2de9ca5c6ce39aecda7",
     "git_hash": "d9eba3dc7af57b6ea650637e4362978299806c4e"
-  },
-  {
-    "date": "2022-09-14",
-    "version": "1.1.4-rc.35-arm64",
-    "container_hash": "b3c7f50c58a7b42d7d16d6d599daf97112d2e378b777f85a70d58502b7892264",
-    "git_hash": "b673716e893218eaada470ce7c75278f6521ab6e"
-  },
-  {
-    "date": "2022-09-14",
-    "version": "1.1.4-rc.35-amd64",
-    "container_hash": "4f9a7064dc70d3f1e7dc481e622dd1527b7873322523df75b39dda8d9768192b",
-    "git_hash": "b673716e893218eaada470ce7c75278f6521ab6e"
-  },
-  {
-    "date": "2022-09-16",
-    "version": "1.1.4-rc.36-amd64",
-    "container_hash": "9ba19b095fa206f98654a0ae895bfa749b9f8924e8b9927da71714a8ec3b64d9",
-    "git_hash": "ea95a1dc9db70aea8192776b4d3525023b163e0f"
-  },
-  {
-    "date": "2022-09-16",
-    "version": "1.1.4-rc.37-amd64",
-    "container_hash": "e552b2eaa3dd6f9e1de6f6f020ce6a0d3898501b55fb944eea8557b92dc96b7d",
-    "git_hash": "8a9029eb35e0fd45ef143f0d75efe64e1382fbac"
-  },
-  {
-    "date": "2022-09-16",
-    "version": "1.1.4-rc.36-arm64",
-    "container_hash": "5330df7082a8921b25cdc31aeaebdf1dbb999ccf225ae1560d890cfc60a6d5a0",
-    "git_hash": "ea95a1dc9db70aea8192776b4d3525023b163e0f"
-  },
-  {
-    "date": "2022-09-16",
-    "version": "1.1.4-rc.38-amd64",
-    "container_hash": "969b720c525940433e7decea71d720f5966b70f5f6dd08354e5c1fc105f8df4e",
-    "git_hash": "f95a3795702c6897620957a6f42e2b146b50753e"
-  },
-  {
-    "date": "2022-09-16",
-    "version": "1.1.4-rc.37-arm64",
-    "container_hash": "3c2686f1dae01bbe2ca7f882028b336f6b8a515f53382b260e4b1e8c673de81f",
-    "git_hash": "8a9029eb35e0fd45ef143f0d75efe64e1382fbac"
-  },
-  {
-    "date": "2022-09-16",
-    "version": "1.1.4-rc.38-arm64",
-    "container_hash": "e31ae5368c40ef8d641a7acb4fda355c3e7b5b08725d11d1253a1e426a4dbdad",
-    "git_hash": "f95a3795702c6897620957a6f42e2b146b50753e"
   },
   {
     "date": "2022-09-20",
@@ -2287,60 +807,6 @@
     "git_hash": "23c20c91d2579b179cb80a4c1824fad78f638a44"
   },
   {
-    "date": "2022-09-22",
-    "version": "1.1.4-rc.39-amd64",
-    "container_hash": "c29e34c84c942253486ba5d2362c5cf254e32d30d2d4866119cc02064244ad7d",
-    "git_hash": "9320c45af98df34f90037ad9b6ce5c746268647e"
-  },
-  {
-    "date": "2022-09-22",
-    "version": "1.1.4-rc.39-arm64",
-    "container_hash": "e17fd94cb95fa71611afa089a3b997ca9e52a3701f8f646cee9b8d96a17058c8",
-    "git_hash": "9320c45af98df34f90037ad9b6ce5c746268647e"
-  },
-  {
-    "date": "2022-09-22",
-    "version": "1.1.4-rc.40-amd64",
-    "container_hash": "8ceb327177545a1aca7b8bf9b3c883a2b9d93a75504c7e8792a9de1671032b93",
-    "git_hash": "850212b4277c553d297dac48b00fd5409fdfebdd"
-  },
-  {
-    "date": "2022-09-22",
-    "version": "1.1.4-rc.41-amd64",
-    "container_hash": "0f2dadf64340453dda944b4e4b27c27da18e5183f7f5602e458ef0708a6c4d4e",
-    "git_hash": "2b379ce2e8f786f1559788dafe4406f5736b02a8"
-  },
-  {
-    "date": "2022-09-22",
-    "version": "1.1.4-rc.40-arm64",
-    "container_hash": "dc9281662c025d33c68cfa38f743f87ca549c16c8bf29c0949173e752a56d096",
-    "git_hash": "850212b4277c553d297dac48b00fd5409fdfebdd"
-  },
-  {
-    "date": "2022-09-22",
-    "version": "1.1.4-rc.41-arm64",
-    "container_hash": "40a167ce3871901973e7dd6c27a744705a09fb3767ab0675a5d58be5a1f71413",
-    "git_hash": "2b379ce2e8f786f1559788dafe4406f5736b02a8"
-  },
-  {
-    "date": "2022-09-26",
-    "version": "1.1.4-rc.42-arm64",
-    "container_hash": "8df6602ef9e6b111f13b43ed7fd82c628ec4fc6849ddb29d48dc6d5b494ad980",
-    "git_hash": "bb082ef67dc7ed8fa003a3395565e3f02758847c"
-  },
-  {
-    "date": "2022-09-26",
-    "version": "1.1.4-rc.42-amd64",
-    "container_hash": "d50bced7e5beea77a394e6c05ba0d90314b4f2ed9614cae17893a997b6e86583",
-    "git_hash": "bb082ef67dc7ed8fa003a3395565e3f02758847c"
-  },
-  {
-    "date": "2022-09-27",
-    "version": "1.1.4-rc.42-arm64",
-    "container_hash": "e3fcaf0d1f45797489efac9cad9316d02cbf6c4b683977e99822ea1a21149db0",
-    "git_hash": "bb082ef67dc7ed8fa003a3395565e3f02758847c"
-  },
-  {
     "date": "2022-09-27",
     "version": "1.1.1-arm64",
     "container_hash": "252e3226fc33a99cf6883bcbfc381013cfa50bc0bfc1a6b1782bd0e9e564647c",
@@ -2381,78 +847,6 @@
     "version": "1.1.3-amd64",
     "container_hash": "140cbbe8162f4d0ffda1a69960b70ef74cc53cb981da1b1c7a9235b0a466dea6",
     "git_hash": "b39f7704f51a0a38c4cd1dc3aea886291dc1e054"
-  },
-  {
-    "date": "2022-09-27",
-    "version": "1.1.4-rc.43-amd64",
-    "container_hash": "898f7e54666c67290d21fc466a2f0515974b2f3d71fbd1fa8f021c517a3bfcc7",
-    "git_hash": "f76922a629914ac328d4b7ea0766151fb66f9b03"
-  },
-  {
-    "date": "2022-09-27",
-    "version": "1.1.4-rc.43-arm64",
-    "container_hash": "c87200c480fb8f26288a92e29acdda8be0a93cb802ba3c4c26ececd83f12e6bb",
-    "git_hash": "f76922a629914ac328d4b7ea0766151fb66f9b03"
-  },
-  {
-    "date": "2022-09-30",
-    "version": "1.1.4-rc.44-arm64",
-    "container_hash": "0569aeb717a6c9284beed869a98dc731583d2e8f436db4227fe23a8b04f438cc",
-    "git_hash": "68dd27783c95cbd6c7cf83f2f4e4b51e6dede815"
-  },
-  {
-    "date": "2022-09-30",
-    "version": "1.1.4-rc.44-amd64",
-    "container_hash": "ae4d0db4424239fced92b4bf7ba7fd43801e077640f41d80865a26b699b76371",
-    "git_hash": "68dd27783c95cbd6c7cf83f2f4e4b51e6dede815"
-  },
-  {
-    "date": "2022-09-30",
-    "version": "1.1.4-rc.45-amd64",
-    "container_hash": "1bd6eebad1e3e54cb53b91fca2838375337bded18af93c4cf660b5d6d63a753a",
-    "git_hash": "73cb60109699a540755918c7994a6dc4cccf683e"
-  },
-  {
-    "date": "2022-09-30",
-    "version": "1.1.4-rc.45-arm64",
-    "container_hash": "6039a73e2e128f5a1cad6eb1b3e9f7d57864156a253aebbe9d53877a98151e28",
-    "git_hash": "73cb60109699a540755918c7994a6dc4cccf683e"
-  },
-  {
-    "date": "2022-09-30",
-    "version": "1.1.4-rc.46-arm64",
-    "container_hash": "f2f56ed5b8ed236cb0f57bfe5cd9c06e36c0e5c5c4d1df4cdadb96adf7074f9e",
-    "git_hash": "3552cca642d82210dc7b865c095683c7d9d81956"
-  },
-  {
-    "date": "2022-09-30",
-    "version": "1.1.4-rc.46-amd64",
-    "container_hash": "486a656df58700871b2e1a62be757d0fe3179928721ef686546b2146f18fe2ba",
-    "git_hash": "3552cca642d82210dc7b865c095683c7d9d81956"
-  },
-  {
-    "date": "2022-09-30",
-    "version": "1.1.4-rc.47-arm64",
-    "container_hash": "77a507056eb87a5f2379e89d4af365cd1960a735da1d026f95442110bc09ea5d",
-    "git_hash": "bded7868d60ec07f1a4e9734fc539096eb8af294"
-  },
-  {
-    "date": "2022-09-30",
-    "version": "1.1.4-rc.47-amd64",
-    "container_hash": "d8091398cacaaa0fc25ee55db5b318d1813b7e8d19ceefd08d2808e0023737d2",
-    "git_hash": "bded7868d60ec07f1a4e9734fc539096eb8af294"
-  },
-  {
-    "date": "2022-10-03",
-    "version": "1.1.4-rc.48-amd64",
-    "container_hash": "f657ca77472f8a60656e5d426ebe589df481d033a4a629eedd710f5de7d77c9a",
-    "git_hash": "b106afacf6e63b36d529c371f51c6dad24095a4f"
-  },
-  {
-    "date": "2022-10-03",
-    "version": "1.1.4-rc.48-arm64",
-    "container_hash": "ffa7d88e4d4c7810a07c9c12926dfe7fa3f3fe0faeb9a19e27793207605bd4b7",
-    "git_hash": "b106afacf6e63b36d529c371f51c6dad24095a4f"
   },
   {
     "date": "2022-10-04",
@@ -2497,54 +891,6 @@
     "git_hash": "d9eba3dc7af57b6ea650637e4362978299806c4e"
   },
   {
-    "date": "2022-10-06",
-    "version": "1.1.4-rc.49-arm64",
-    "container_hash": "73345b5a6f718efdb94e780395f6bf48d7aababae61995276f5cf1d2b5398c3d",
-    "git_hash": "48256b1f67164cfd06c7c7b15c376d5a3c53cd3c"
-  },
-  {
-    "date": "2022-10-06",
-    "version": "1.1.4-rc.49-amd64",
-    "container_hash": "4dd7355e7ba66451c037bf09d034995910a305e7d5827eb859ed8b63e231941e",
-    "git_hash": "48256b1f67164cfd06c7c7b15c376d5a3c53cd3c"
-  },
-  {
-    "date": "2022-10-06",
-    "version": "1.1.4-rc.50-arm64",
-    "container_hash": "8f87bcaa783f8638e5d459d3887887c6c65597377dd9b9cf25fccc4e95546a4b",
-    "git_hash": "fb94e287d0034b4077af1c8615fed36a10060ff2"
-  },
-  {
-    "date": "2022-10-06",
-    "version": "1.1.4-rc.50-amd64",
-    "container_hash": "221214fc668c653981ffe958d25e55b32732b0deda3b36d6c7f4c89a057e13aa",
-    "git_hash": "fb94e287d0034b4077af1c8615fed36a10060ff2"
-  },
-  {
-    "date": "2022-10-06",
-    "version": "1.1.4-rc.51-arm64",
-    "container_hash": "9b78085d460d3974b2c7bc0186e7b5c8cd97813a1541457b75319882f20b3406",
-    "git_hash": "ade6d3519402c05dec8656875ba9ea37b842a850"
-  },
-  {
-    "date": "2022-10-06",
-    "version": "1.1.4-rc.51-amd64",
-    "container_hash": "7cedd923a1302748ee8bb96fc765adf25a5b91b9d4bc98981764f6d930391b03",
-    "git_hash": "ade6d3519402c05dec8656875ba9ea37b842a850"
-  },
-  {
-    "date": "2022-10-10",
-    "version": "1.1.4-rc.52-amd64",
-    "container_hash": "f1500bcdc1b061b96d439b6ebb7279c0ddd81b62bf98986a03326eb34fb2acd9",
-    "git_hash": "8ba7faee0f6231d0e0552c9ce3644aa6b577faf4"
-  },
-  {
-    "date": "2022-10-10",
-    "version": "1.1.4-rc.52-arm64",
-    "container_hash": "ef2b817101b01ccf4934924901b3381aad0764fe69d9640aed2970a56df9657e",
-    "git_hash": "8ba7faee0f6231d0e0552c9ce3644aa6b577faf4"
-  },
-  {
     "date": "2022-10-11",
     "version": "1.1.1-arm64",
     "container_hash": "d15f7f83f17af61c0c0d053a45ed1af1a3b3c7c465a1ad3a252ff0b264991803",
@@ -2585,42 +931,6 @@
     "version": "1.1.0",
     "container_hash": "411411d226d4e1a4fb1cc9a358bbf22b63b841d3420add5dbac9f05d976cd61e",
     "git_hash": "c6d79fd869a072d804e21edaf479bf71e41f5834"
-  },
-  {
-    "date": "2022-10-14",
-    "version": "1.1.4-rc.53-arm64",
-    "container_hash": "058ee11b3dc6f7c760c0c580d6e7fc2c319287d1f87a4845f9ee824e37a2a778",
-    "git_hash": "db0f33a93a54a68011a785f74f983741643492b0"
-  },
-  {
-    "date": "2022-10-14",
-    "version": "1.1.4-rc.54-arm64",
-    "container_hash": "d4b01e4c6fc01699a57af1a22842d8bf3a3b3cfab747d95daac0b3da087ed8b8",
-    "git_hash": "d043efd3491184f3e22e30c0be6fda7d67264a89"
-  },
-  {
-    "date": "2022-10-14",
-    "version": "1.1.4-rc.53-amd64",
-    "container_hash": "0627205578d4ff49629be41c6768c6b7e04092b3b60e8311d4e6f5493c56e6ef",
-    "git_hash": "db0f33a93a54a68011a785f74f983741643492b0"
-  },
-  {
-    "date": "2022-10-14",
-    "version": "1.1.4-rc.54-amd64",
-    "container_hash": "198b613e6d2e41d8c358b54cfd818fe9edbb42c1ef2e099a1edf75019485ba10",
-    "git_hash": "d043efd3491184f3e22e30c0be6fda7d67264a89"
-  },
-  {
-    "date": "2022-10-17",
-    "version": "1.1.4-rc.55-amd64",
-    "container_hash": "60ed61ef3f264f37451ce0ad398d0e78dd838e5a843698c9d933715d294b0641",
-    "git_hash": "dcd0f10bf933300fd2fa6f469abb47b3f14dd2f8"
-  },
-  {
-    "date": "2022-10-17",
-    "version": "1.1.4-rc.55-arm64",
-    "container_hash": "5deac3b5560e7dcbe653bdff019956d0d4fa7a1641fe6c9830740432298fea32",
-    "git_hash": "dcd0f10bf933300fd2fa6f469abb47b3f14dd2f8"
   },
   {
     "date": "2022-10-18",
@@ -2665,30 +975,6 @@
     "git_hash": "23c20c91d2579b179cb80a4c1824fad78f638a44"
   },
   {
-    "date": "2022-10-18",
-    "version": "1.1.4-rc.56-amd64",
-    "container_hash": "47b2c58c10fe7a8888c6e002774a094da3eea69d505d987e598b4f49e28a8782",
-    "git_hash": "585dae38a60d81cf935180cc6904349ecb048eb0"
-  },
-  {
-    "date": "2022-10-18",
-    "version": "1.1.4-rc.56-arm64",
-    "container_hash": "6f95f52e9b4f08d4604a244eae3d67aaa919ffe5fa72726b682eb8e1bcb3e490",
-    "git_hash": "585dae38a60d81cf935180cc6904349ecb048eb0"
-  },
-  {
-    "date": "2022-10-24",
-    "version": "1.1.4-rc.57-arm64",
-    "container_hash": "e54706483671f30a96c185a052539373555295b2b9a5584628ea731395dc66ef",
-    "git_hash": "fa35723b25616d56de5874ae9b8d2cbaf87f676c"
-  },
-  {
-    "date": "2022-10-24",
-    "version": "1.1.4-rc.57-amd64",
-    "container_hash": "49e41247b3b57bb17ac6100fb55b14c756ee7d5490afd1316f3edab5e4b3fe2b",
-    "git_hash": "fa35723b25616d56de5874ae9b8d2cbaf87f676c"
-  },
-  {
     "date": "2022-10-25",
     "version": "1.1.3-amd64",
     "container_hash": "8d6498a3c14370a837de0b2f97cb554b70c7cd0b4de0991d3ec84f126e12e8be",
@@ -2729,30 +1015,6 @@
     "version": "1.1.2-arm64",
     "container_hash": "9952da796bf042defb33dab040f424667c35afe536e12b128e77e56f3e607505",
     "git_hash": "23c20c91d2579b179cb80a4c1824fad78f638a44"
-  },
-  {
-    "date": "2022-10-31",
-    "version": "1.1.4-rc.58-arm64",
-    "container_hash": "ee758dc34526920e7f8c96ed21455ef21b3879db9f77c6d8e6e5f59c1353dd4b",
-    "git_hash": "295f3709b5cd7b018a99d7cb46d3325d2b1c27e1"
-  },
-  {
-    "date": "2022-10-31",
-    "version": "1.1.4-rc.58-amd64",
-    "container_hash": "912805fda9718e8731e50d8cf651e67f08492ac9e1982311e9fd3815512c54c4",
-    "git_hash": "295f3709b5cd7b018a99d7cb46d3325d2b1c27e1"
-  },
-  {
-    "date": "2022-10-31",
-    "version": "1.1.4-rc.59-amd64",
-    "container_hash": "8a879675ac520fb2f8e8015c7e90d0dbb0a69e0fe769cc24c2eea068453f5410",
-    "git_hash": "5358854ec43fbf18cc0aea55743b1c0413f927b8"
-  },
-  {
-    "date": "2022-10-31",
-    "version": "1.1.4-rc.59-arm64",
-    "container_hash": "2fee6604d85e03d31b05c8b45104e3b69012e3fcd0b6519e2483926e5e513a4c",
-    "git_hash": "5358854ec43fbf18cc0aea55743b1c0413f927b8"
   },
   {
     "date": "2022-11-01",
@@ -2804,18 +1066,6 @@
   },
   {
     "date": "2022-11-08",
-    "version": "2.0.0-rc.0-arm64",
-    "container_hash": "8147df276bcaf8c7605aacb5084e5617a2ccb74e8a57c1204cd968fa0c8f89f6",
-    "git_hash": "eb27e7fa240c2340eb0202f93b07e75840a8253d"
-  },
-  {
-    "date": "2022-11-08",
-    "version": "2.0.0-rc.0-amd64",
-    "container_hash": "c1be63211ebf46b881d2e86554db5ea524d7bd1738360076e400025af84ee96f",
-    "git_hash": "eb27e7fa240c2340eb0202f93b07e75840a8253d"
-  },
-  {
-    "date": "2022-11-08",
     "version": "2.0.0-arm64",
     "container_hash": "968bcc94e7fab0b1e39af9068c183e715be85ab04a82dac808354c53af50817a",
     "git_hash": "2a47ac02ed351ce31fb3ba1c9f92045603c1c623"
@@ -2825,18 +1075,6 @@
     "version": "2.0.0-amd64",
     "container_hash": "61c66122b46b1270cf49d9d94289fc4a3e26d2195699341d9b57fd9c622f93a6",
     "git_hash": "2a47ac02ed351ce31fb3ba1c9f92045603c1c623"
-  },
-  {
-    "date": "2022-11-11",
-    "version": "2.0.1-rc.0-arm64",
-    "container_hash": "7b232cf0ea02a343bfac44e915950fad611f28fc759f0c90781b1ea791f97659",
-    "git_hash": "c903ec05ed608540cbbdf866558864ec5a62733f"
-  },
-  {
-    "date": "2022-11-11",
-    "version": "2.0.1-rc.0-amd64",
-    "container_hash": "ca411a44bbc89967a01bc55aa6d0fdd18680e964f1862a28fd70062df403768c",
-    "git_hash": "c903ec05ed608540cbbdf866558864ec5a62733f"
   },
   {
     "date": "2022-11-15",
@@ -2893,42 +1131,6 @@
     "git_hash": "2a47ac02ed351ce31fb3ba1c9f92045603c1c623"
   },
   {
-    "date": "2022-11-17",
-    "version": "2.0.1-rc.1-arm64",
-    "container_hash": "d95275cc2de2e7b2173b13b424f806717c5cb6ec30c3de7327529ebc34b6acf3",
-    "git_hash": "859540d9cbe074df6793b5523921a7400a46de6d"
-  },
-  {
-    "date": "2022-11-17",
-    "version": "2.0.1-rc.1-amd64",
-    "container_hash": "98d1d30c7edaab50ddf6ba8d5c3e707cf16c7d9e6de2e75795255067290f17b5",
-    "git_hash": "859540d9cbe074df6793b5523921a7400a46de6d"
-  },
-  {
-    "date": "2022-11-17",
-    "version": "2.0.1-rc.2-arm64",
-    "container_hash": "15498b7f245db8beae0d3d652c060ff69ded87fe9c90a8ec754e4fd3b77bbc85",
-    "git_hash": "efdecbf755f46d757faaf30c2f14439dbcdd9c46"
-  },
-  {
-    "date": "2022-11-17",
-    "version": "2.0.1-rc.2-amd64",
-    "container_hash": "1e8bbceb5559ee6f8cc25e16a5454cfb69181110adb02537b8345bd30c1bc198",
-    "git_hash": "efdecbf755f46d757faaf30c2f14439dbcdd9c46"
-  },
-  {
-    "date": "2022-11-21",
-    "version": "2.0.1-rc.3-arm64",
-    "container_hash": "b2925680a7340f99083e119547866f2c47ae1616a35031f98c467ace2765dd26",
-    "git_hash": "8d2222dda84ff9d3119e68819d9a8e919e7fd2c4"
-  },
-  {
-    "date": "2022-11-21",
-    "version": "2.0.1-rc.3-amd64",
-    "container_hash": "0ffd4e06a9ee25f9421a87341564ade34ae438da2916e29638126010a0d0d4e3",
-    "git_hash": "8d2222dda84ff9d3119e68819d9a8e919e7fd2c4"
-  },
-  {
     "date": "2022-11-22",
     "version": "1.1.3-arm64",
     "container_hash": "c16cc81ff4d4d691d323c2729c2ca50066fcec9652e852055a014c52d3fbc3c8",
@@ -2981,30 +1183,6 @@
     "version": "1.1.2-arm64",
     "container_hash": "f4f462eb05fb7900ef52eeac9e90d35647a72047f9c66c93dd9b2fd75710a49c",
     "git_hash": "23c20c91d2579b179cb80a4c1824fad78f638a44"
-  },
-  {
-    "date": "2022-11-28",
-    "version": "2.0.1-rc.4-amd64",
-    "container_hash": "d85fa008fc4f8a3a21282392a9cd6c7cddebdfda05a7a11d572e0a6a7196efdd",
-    "git_hash": "3f249a52590d3e556d5b698ac7b0b10f89e6ffcc"
-  },
-  {
-    "date": "2022-11-28",
-    "version": "2.0.1-rc.4-arm64",
-    "container_hash": "82cde7eaa192f98671f6c20b1206d20e01bbeee37f09854e511ca57db5702de8",
-    "git_hash": "3f249a52590d3e556d5b698ac7b0b10f89e6ffcc"
-  },
-  {
-    "date": "2022-11-28",
-    "version": "2.0.1-rc.5-arm64",
-    "container_hash": "d99e25ed68b89a0f6dcecb7928a2ab1dfbbcf3c3ee49249526d4b91d0e34b94c",
-    "git_hash": "dc4c4c688e1620694c7ca730435f97bb4b4e1e5c"
-  },
-  {
-    "date": "2022-11-28",
-    "version": "2.0.1-rc.5-amd64",
-    "container_hash": "a5107dbfe18e6ae385ee71a4019eccefd937b99c79877812f9816d1c7d9a4d31",
-    "git_hash": "dc4c4c688e1620694c7ca730435f97bb4b4e1e5c"
   },
   {
     "date": "2022-11-29",
@@ -3061,118 +1239,10 @@
     "git_hash": "23c20c91d2579b179cb80a4c1824fad78f638a44"
   },
   {
-    "date": "2022-11-30",
-    "version": "2.0.1-rc.6-arm64",
-    "container_hash": "59534e65299c68a916eae0b2eb9d1574e4f0660a910e89b355e27add02324419",
-    "git_hash": "68aecba396622f27f53bcd8f55594b24a79de728"
-  },
-  {
-    "date": "2022-11-30",
-    "version": "2.0.1-rc.6-amd64",
-    "container_hash": "0b0def21a5a49034da45186742c043efab697de247f8d2679948bf98806f21f8",
-    "git_hash": "68aecba396622f27f53bcd8f55594b24a79de728"
-  },
-  {
-    "date": "2022-11-30",
-    "version": "2.0.1-rc.7-arm64",
-    "container_hash": "2d92f98767d194f6c2d076478c242c8cffe0b48c7251c839188306148e00cd87",
-    "git_hash": "5f15f9f0b5c12b947bd889b923ed64d8b001e150"
-  },
-  {
-    "date": "2022-11-30",
-    "version": "2.0.1-rc.7-amd64",
-    "container_hash": "f4b9e0383771cd23c90011a9b154b2c9157e7c6cad2831e1f0fa778b073aaaab",
-    "git_hash": "5f15f9f0b5c12b947bd889b923ed64d8b001e150"
-  },
-  {
-    "date": "2022-11-30",
-    "version": "2.0.1-rc.8-arm64",
-    "container_hash": "3d019be7f9dd628f40549e010b0866b91dcc5575e9fcb5d0ac72fe397fa4e479",
-    "git_hash": "915cff31491b30d9f9a7efcca553d75e4d406b21"
-  },
-  {
-    "date": "2022-11-30",
-    "version": "2.0.1-rc.8-amd64",
-    "container_hash": "60db43eca372f2c6d3d13cafad53063889d54838407098e720035b40a57794af",
-    "git_hash": "915cff31491b30d9f9a7efcca553d75e4d406b21"
-  },
-  {
-    "date": "2022-11-30",
-    "version": "2.0.1-rc.9-arm64",
-    "container_hash": "44dc7ec5a175430d44671aa241868e26a9860d213b8005eb61bea27b800e0e74",
-    "git_hash": "706f77a0134e68180bbc831e3895219fd5bbb669"
-  },
-  {
-    "date": "2022-11-30",
-    "version": "2.0.1-rc.9-amd64",
-    "container_hash": "fc8850846cb43597190a3988a5d1bf6f06cfcec27360e22efd940f030038a4db",
-    "git_hash": "706f77a0134e68180bbc831e3895219fd5bbb669"
-  },
-  {
-    "date": "2022-11-30",
-    "version": "2.0.1-rc.10-arm64",
-    "container_hash": "d35a22063e34ba18ff2c74fc46b3eb7eac352a48c23c4948f2cf3c4b02c83e7e",
-    "git_hash": "893fecac264174464123962e275aa9b69301235f"
-  },
-  {
-    "date": "2022-11-30",
-    "version": "2.0.1-rc.10-amd64",
-    "container_hash": "186a5a0b69ad2fb937b07b3a4575097440849dd8f2ccd5c943d019981196238d",
-    "git_hash": "893fecac264174464123962e275aa9b69301235f"
-  },
-  {
-    "date": "2022-12-01",
-    "version": "2.0.1-rc.11-arm64",
-    "container_hash": "73b28c74a8a5d5b2f1eaac1cf17d0bebc8aa1369956ca896091bca6ba47b1c7b",
-    "git_hash": "28324d7bed7edc48050599816992172dbe3a102b"
-  },
-  {
-    "date": "2022-12-02",
-    "version": "2.0.1-rc.11-amd64",
-    "container_hash": "3c05b1ebd18aac2021098a830b2760750a5557e4a97f9494a54940e2eac4ea56",
-    "git_hash": "28324d7bed7edc48050599816992172dbe3a102b"
-  },
-  {
-    "date": "2022-12-02",
-    "version": "2.0.1-rc.12-arm64",
-    "container_hash": "5dbbfac474095663c3d66ebd055d898650f0b052cb9d8e279613a276cda45003",
-    "git_hash": "ba4f4c5203938b47ab89e95d63a9196218d9817a"
-  },
-  {
-    "date": "2022-12-02",
-    "version": "2.0.1-rc.12-amd64",
-    "container_hash": "56bf7b9c32eddb997bea209c63c0b95d3a30416638f8b772b925c956354f7e11",
-    "git_hash": "ba4f4c5203938b47ab89e95d63a9196218d9817a"
-  },
-  {
-    "date": "2022-12-05",
-    "version": "2.0.1-rc.13-amd64",
-    "container_hash": "bf7958cac8a23f3943e8370900e1b4f0804563de3498a7f5b1534d3d9d7cbb82",
-    "git_hash": "e428506b9155ad5a49fe6fb70d72ec64022783fc"
-  },
-  {
-    "date": "2022-12-05",
-    "version": "2.0.1-rc.13-arm64",
-    "container_hash": "9a32ac18827b8922e3019a909123667af55c4e4ae1c6a50884e0893e389c98ef",
-    "git_hash": "e428506b9155ad5a49fe6fb70d72ec64022783fc"
-  },
-  {
     "date": "2022-12-06",
     "version": "1.1.0",
     "container_hash": "54503e9be4240427ee86149f1dfc375a281a5183928f6d7cfb39fd599918d500",
     "git_hash": "c6d79fd869a072d804e21edaf479bf71e41f5834"
-  },
-  {
-    "date": "2022-12-06",
-    "version": "2.0.1-rc.15-arm64",
-    "container_hash": "c2e64eb76c66546514eacbc35b5979af060d30f45fa7569625364f8722380047",
-    "git_hash": "8a92c4240431cbfc076705583d59a498a4d7a265"
-  },
-  {
-    "date": "2022-12-06",
-    "version": "2.0.1-rc.15-amd64",
-    "container_hash": "3de58a1344f4937b9b070882235b077daa74a2e4804e6d5e447c0674462185fa",
-    "git_hash": "8a92c4240431cbfc076705583d59a498a4d7a265"
   },
   {
     "date": "2022-12-06",
@@ -3185,60 +1255,6 @@
     "version": "2.1.0-amd64",
     "container_hash": "d85aced245954a2f06198d28de8c1a954a9a148ce7e44f417565d87d86e9ac25",
     "git_hash": "a696e0b1de86351865b30b2fc7f3c02361937037"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "2.1.1-rc.0-arm64",
-    "container_hash": "6cd913482aec765eaaa116b010a02641ec1cb75ba14ccc203955474f4de27d78",
-    "git_hash": "6e0beb2f5a3bd9609ddf9eeff601cffe2ba1ca34"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "2.1.1-rc.0-amd64",
-    "container_hash": "9b5c6421dde53f579ff5f2432d4d2100cd3f20e59f4ef1c341fa3713f7f32362",
-    "git_hash": "6e0beb2f5a3bd9609ddf9eeff601cffe2ba1ca34"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "2.1.1-rc.1-amd64",
-    "container_hash": "050c2fd35d9504d1a8fbd1f451de6a2e8bb3b446b1888eb6280b80d48c7b1857",
-    "git_hash": "6a6e569c765c3252a6aba94cfb0848065f302e70"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "2.1.1-rc.1-arm64",
-    "container_hash": "52cc2c2e877391d92bd7a1d523aac420d7c79fe825dd2c7399ea789b127cdc5e",
-    "git_hash": "6a6e569c765c3252a6aba94cfb0848065f302e70"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "2.1.1-rc.0-arm64",
-    "container_hash": "c00f13dc5bd5e537791d6c4bbb836c577ff05d02a32d63459496f1a55aa3ddc3",
-    "git_hash": "6e0beb2f5a3bd9609ddf9eeff601cffe2ba1ca34"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "2.1.1-rc.2-amd64",
-    "container_hash": "cc8134979a56a023ee3644e65a7b87bef12501fc5049a133fcbff9b72c29815e",
-    "git_hash": "d2ef41a2533a3434193d26f04f8b33227631aa5f"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "2.1.1-rc.3-amd64",
-    "container_hash": "2ea70b76bb0f11086753c8e0377ac87374a183c0d2a811b1309249cd28e87f6c",
-    "git_hash": "6415f4e7dd979383fd99d1ef7e24aea791766f2a"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "2.1.1-rc.2-arm64",
-    "container_hash": "1d7c0018543f2c138c3c8c47ea30f2602add009c61e550d493499e050706d786",
-    "git_hash": "d2ef41a2533a3434193d26f04f8b33227631aa5f"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "2.1.1-rc.3-arm64",
-    "container_hash": "6cfa7029a58bfc97c90a2ea3e6f0b7ec3ad03089b97d1407efe71241475458b2",
-    "git_hash": "6415f4e7dd979383fd99d1ef7e24aea791766f2a"
   },
   {
     "date": "2022-12-13",
@@ -3307,54 +1323,6 @@
     "git_hash": "a696e0b1de86351865b30b2fc7f3c02361937037"
   },
   {
-    "date": "2022-12-16",
-    "version": "2.1.1-rc.4-arm64",
-    "container_hash": "e8e6bfe3d698354e2e610e2fbcd9c72ebc4d4e54b8e1dfd24ef5fa337e6922b5",
-    "git_hash": "7c0a57df7e4e3234f6dc63c69064986e2d6984a7"
-  },
-  {
-    "date": "2022-12-16",
-    "version": "2.1.1-rc.4-amd64",
-    "container_hash": "88775debe89d96f21e0ef73ff82a57db46b514cc51d9ee79f75eb4ca2d11e84d",
-    "git_hash": "7c0a57df7e4e3234f6dc63c69064986e2d6984a7"
-  },
-  {
-    "date": "2022-12-23",
-    "version": "2.1.1-rc.5-arm64",
-    "container_hash": "c5d75e880551f45aa8f2303176bf7b1faae23eb3eb06651b36cd4437d051b46b",
-    "git_hash": "b9660bcc35e46ce352021d8ba4f7474679695f5d"
-  },
-  {
-    "date": "2022-12-23",
-    "version": "2.1.1-rc.6-amd64",
-    "container_hash": "0bca5713fa7670f05d35cc6699458243d75626812bd4402a714eaeb3a547d7f7",
-    "git_hash": "4c6bfbd62381e140644e6f1d335eea646a6bcecc"
-  },
-  {
-    "date": "2022-12-23",
-    "version": "2.1.1-rc.6-arm64",
-    "container_hash": "c6c6e2570a43b7ff9ffccca224d292bcf138cf0f50bc040a02ed9e36daf92489",
-    "git_hash": "4c6bfbd62381e140644e6f1d335eea646a6bcecc"
-  },
-  {
-    "date": "2022-12-23",
-    "version": "2.1.1-rc.5-amd64",
-    "container_hash": "9e82be24ae9607a5f05b7060eeca351a297bdb1d345e7cd143c5ecac0471815a",
-    "git_hash": "b9660bcc35e46ce352021d8ba4f7474679695f5d"
-  },
-  {
-    "date": "2022-12-29",
-    "version": "2.1.1-rc.8-arm64",
-    "container_hash": "c344a0af13adfef226d4eb07145516cdf6c7583f99380b4701fae093c6ce365e",
-    "git_hash": "9c9978c0c58b1d5573d26baecbb8bff774784278"
-  },
-  {
-    "date": "2022-12-29",
-    "version": "2.1.1-rc.8-amd64",
-    "container_hash": "b5765fa401b4325085e2f59aa7a615da40f22061bba803d64258c36c58b55f02",
-    "git_hash": "9c9978c0c58b1d5573d26baecbb8bff774784278"
-  },
-  {
     "date": "2023-01-03",
     "version": "2.1.1-arm64",
     "container_hash": "3aa69b7d2974d15697b53434ebbc64180c919f3ec1ac5ecd6cd346629a4c3ff3",
@@ -3365,30 +1333,6 @@
     "version": "2.1.1-amd64",
     "container_hash": "dd202b6289cb4c06beee7b8484fb7ce67d3e6fb2b402da9b8915b2fbbc758953",
     "git_hash": "b16966bfc003bb8d19fae78ee4e41c7a87f5e241"
-  },
-  {
-    "date": "2023-01-05",
-    "version": "2.1.2-rc.0-arm64",
-    "container_hash": "6eb189d578b3f756bfccaca3f0b51cc4ceb86024c122cf8e2e3ed3c7357785de",
-    "git_hash": "69ffba2de810bea5bc19760f7e28b07b9894b434"
-  },
-  {
-    "date": "2023-01-05",
-    "version": "2.1.2-rc.0-amd64",
-    "container_hash": "67a06fd886b1a328cd4e48c22878c70eca31a2c8631cbcf4df60e73275a272a8",
-    "git_hash": "69ffba2de810bea5bc19760f7e28b07b9894b434"
-  },
-  {
-    "date": "2023-01-09",
-    "version": "2.1.2-rc.2-arm64",
-    "container_hash": "1c0b0cb9010862ed68393c1332b59c0ff4ed1af6a076b54537b0dabc2ad582be",
-    "git_hash": "82cfd436e2fafff926eb44a816d89e839a5a3e9b"
-  },
-  {
-    "date": "2023-01-09",
-    "version": "2.1.2-rc.2-amd64",
-    "container_hash": "58826cbc5479a4722a418da061a43a9941a67298be28d8de3394c3c2d8b56f47",
-    "git_hash": "82cfd436e2fafff926eb44a816d89e839a5a3e9b"
   },
   {
     "date": "2023-01-10",
@@ -3469,30 +1413,6 @@
     "git_hash": "b39f7704f51a0a38c4cd1dc3aea886291dc1e054"
   },
   {
-    "date": "2023-01-10",
-    "version": "2.1.2-rc.3-amd64",
-    "container_hash": "c181417707ed36460707751b773a7bbc473bfab9a8bf8f89ba0f64f0fef586ef",
-    "git_hash": "c4d0b01e451a674d7f18ec4a19c476cf0f1f5ee5"
-  },
-  {
-    "date": "2023-01-10",
-    "version": "2.1.2-rc.3-arm64",
-    "container_hash": "db4ff2d407ae85b3b5580d7eb70fec66248a35fb2e2b76092f825af6514e0ffc",
-    "git_hash": "c4d0b01e451a674d7f18ec4a19c476cf0f1f5ee5"
-  },
-  {
-    "date": "2023-01-12",
-    "version": "2.1.2-rc.4-arm64",
-    "container_hash": "940c6640994305a9cd4d5e653c26e281bfa7cec481ab7751000711ed205d23ed",
-    "git_hash": "b0371252519ac6df0048e23152a0595e9b52c52b"
-  },
-  {
-    "date": "2023-01-13",
-    "version": "2.1.2-rc.4-amd64",
-    "container_hash": "4eaf9665c85c6d360f4f6a6d2e446869aaeb001ff3e0cc9a8e8995c1fa9ad5b5",
-    "git_hash": "b0371252519ac6df0048e23152a0595e9b52c52b"
-  },
-  {
     "date": "2023-01-13",
     "version": "2.0.0-arm64",
     "container_hash": "5b4990d69ce2634a6fc6b6345156346980b9cb26db22697b73e45823d8bfd602",
@@ -3548,27 +1468,9 @@
   },
   {
     "date": "2023-01-13",
-    "version": "2.1.2-rc.5-amd64",
-    "container_hash": "32ae208dda933f875acc0dcd4f900f4f5bf9043236807df16c4fb4c3394f8101",
-    "git_hash": "354157c408aca6d7f08927daf48d8b5c49a7c2a6"
-  },
-  {
-    "date": "2023-01-13",
     "version": "1.1.1-arm64",
     "container_hash": "1716b92b338da03306d25d2fc36f0259099267651b604104464d4ecf4e682128",
     "git_hash": "d9eba3dc7af57b6ea650637e4362978299806c4e"
-  },
-  {
-    "date": "2023-01-13",
-    "version": "2.1.2-rc.6-amd64",
-    "container_hash": "a31f377fcbd9ff7d44470d6532f48ad6d5c870610b2b11201be8710563c0ca3b",
-    "git_hash": "cb783fe0cead6695ed7ad7b68d98ab27832a5408"
-  },
-  {
-    "date": "2023-01-13",
-    "version": "2.1.2-rc.7-amd64",
-    "container_hash": "efa61c62d0f754bc45c38c7c7b7d51e1da603224c11e2c18fa9acbc2833b7b2d",
-    "git_hash": "cfbca627f0a0384e53bed6623baa55b2969a054b"
   },
   {
     "date": "2023-01-13",
@@ -3587,36 +1489,6 @@
     "version": "1.1.2-arm64",
     "container_hash": "61c9976e918ae9299e72b8b23dc18fede331d26bc4133fb822d2b5bec72685d8",
     "git_hash": "23c20c91d2579b179cb80a4c1824fad78f638a44"
-  },
-  {
-    "date": "2023-01-13",
-    "version": "2.1.2-rc.5-arm64",
-    "container_hash": "ff493180f8877e3ccf288be73a88e9f0c779685bf27bce29094d96fc49e30b99",
-    "git_hash": "354157c408aca6d7f08927daf48d8b5c49a7c2a6"
-  },
-  {
-    "date": "2023-01-13",
-    "version": "2.1.2-rc.8-amd64",
-    "container_hash": "22762cf16f3241372c58b234395f3efd0267ff8518b2f7232f027b45485aeb8f",
-    "git_hash": "dc8fd0878464ed3ca246d87c39b0bc77351896bc"
-  },
-  {
-    "date": "2023-01-13",
-    "version": "2.1.2-rc.6-arm64",
-    "container_hash": "c21e9cfeccb7ebe340b06eda36b48d95661d42947f04923386d2d7c782bb421b",
-    "git_hash": "cb783fe0cead6695ed7ad7b68d98ab27832a5408"
-  },
-  {
-    "date": "2023-01-13",
-    "version": "2.1.2-rc.7-arm64",
-    "container_hash": "d866298595ff9910dc3af76dcdb112e1eda18fae3cb96e51521c33b836a7320b",
-    "git_hash": "cfbca627f0a0384e53bed6623baa55b2969a054b"
-  },
-  {
-    "date": "2023-01-13",
-    "version": "2.1.2-rc.8-arm64",
-    "container_hash": "f7d53629801a547b4b8267f2b1c6c71ce91beb05e2251e2f8be3701055368ae9",
-    "git_hash": "dc8fd0878464ed3ca246d87c39b0bc77351896bc"
   },
   {
     "date": "2023-01-17",
@@ -3698,63 +1570,15 @@
   },
   {
     "date": "2023-01-18",
-    "version": "2.1.2-rc.9-arm64",
-    "container_hash": "7fdb4cfd4844f9561cf4af31d233d47edc3186db16ca2d5cd0cc02327591aced",
-    "git_hash": "639e4102240d905466423a940be6060ef6d42207"
-  },
-  {
-    "date": "2023-01-18",
-    "version": "2.1.2-rc.9-amd64",
-    "container_hash": "cab0033674ed74885c35abc605403a8ec8a73d3937c2a3488996a364dea03cae",
-    "git_hash": "639e4102240d905466423a940be6060ef6d42207"
-  },
-  {
-    "date": "2023-01-18",
-    "version": "2.1.2-rc.10-arm64",
-    "container_hash": "987f8496de96ab1982828fd0843461bbf1fbe2bb30ae79da3626b1dfd9ad6c28",
-    "git_hash": "a8512b01144943acb7170628cd808cb8a5dda236"
-  },
-  {
-    "date": "2023-01-18",
     "version": "2.1.2-arm64",
     "container_hash": "e2fa459c2b6a357d55944a34f839d9d427021809fa36d521450ab3fc2429997d",
     "git_hash": "442678ba34d42f1207c4c862e10d9e985464c226"
   },
   {
     "date": "2023-01-18",
-    "version": "2.1.2-rc.10-amd64",
-    "container_hash": "6fbd4ff4c6a55fdb603bf0b0fa26b1c99052f82f255c5d9cf639ec65b96141c2",
-    "git_hash": "a8512b01144943acb7170628cd808cb8a5dda236"
-  },
-  {
-    "date": "2023-01-18",
     "version": "2.1.2-amd64",
     "container_hash": "ddc3740b8294096226d617709e7b30382815886beef920516b8e7c45857516b4",
     "git_hash": "442678ba34d42f1207c4c862e10d9e985464c226"
-  },
-  {
-    "date": "2023-01-19",
-    "version": "2.1.3-rc.0-arm64",
-    "container_hash": "ed5ea686533742c83e78b3f7d70f5303b0b42b5f5f29ad9094918b97e066b293",
-    "git_hash": "b7ea1208c612c27bbbaea1e0064767ff14e34309"
-  },
-  {
-    "date": "2023-01-19",
-    "version": "2.1.3-rc.0-amd64",
-    "container_hash": "ede98d29ec3766886a2a0bf3ffaf4cc71d4d232f67b47cf0aa40d9b927e2f219",
-    "git_hash": "b7ea1208c612c27bbbaea1e0064767ff14e34309"
-  },
-  {
-    "date": "2023-01-23",
-    "version": "2.1.3-rc.1-arm64",
-    "container_hash": "104bedc50d0a1410a46ffd82efacb6079d2febba634a47484eab2c3749e1a3e9",
-    "git_hash": "4e5c9021a7f84ebc1b5741326c73a94b2580f335"
-  },
-  {
-    "date": "2023-01-23",
-    "version": "2.1.3-rc.1-amd64",
-    "container_hash": "9fb37a43fb33aadd8a8bbd1940da571f332fb092f052088fd9cf958bf6ec677d",
-    "git_hash": "4e5c9021a7f84ebc1b5741326c73a94b2580f335"
   },
   {
     "date": "2023-01-24",
@@ -3833,54 +1657,6 @@
     "version": "2.1.0-arm64",
     "container_hash": "6760ae4dc2b2b92e4ba76799bd97cc3c832fecbe7b1471ede541e4d1597c4804",
     "git_hash": "a696e0b1de86351865b30b2fc7f3c02361937037"
-  },
-  {
-    "date": "2023-01-25",
-    "version": "2.1.3-rc.2-arm64",
-    "container_hash": "92b54a3c30b934b7a320c444c282cb9aae70d875b2e8a3b7123ffd36c830fadb",
-    "git_hash": "448494abc510902082b515d3ce561b1fd64fddb3"
-  },
-  {
-    "date": "2023-01-25",
-    "version": "2.1.3-rc.2-amd64",
-    "container_hash": "a98eb92b03d410b85e9b42faa96dfcb4f88169d40a56bc5c69a4404de2780825",
-    "git_hash": "448494abc510902082b515d3ce561b1fd64fddb3"
-  },
-  {
-    "date": "2023-01-26",
-    "version": "2.1.3-rc.3-arm64",
-    "container_hash": "724f10fdb7dcfd858afeebb6dc0cb1e99288de298457a29abdb9e355b9800006",
-    "git_hash": "93caa90054a7c73c0bc62bbcda5dadb8f49b2f24"
-  },
-  {
-    "date": "2023-01-26",
-    "version": "2.1.3-rc.3-amd64",
-    "container_hash": "f8537af23784c6f18b9288660379d28af9ae463e95b478dc6cbe430a6307262b",
-    "git_hash": "93caa90054a7c73c0bc62bbcda5dadb8f49b2f24"
-  },
-  {
-    "date": "2023-01-26",
-    "version": "2.1.3-rc.4-arm64",
-    "container_hash": "cff662cd9daa89d420ce8dabc195ee116051fd8a5163fcda41c3dcca6409f36e",
-    "git_hash": "76e4e4a0a83bb4bf0dd5895e00f6c27d0ea02c19"
-  },
-  {
-    "date": "2023-01-26",
-    "version": "2.1.3-rc.4-amd64",
-    "container_hash": "00bb5748c9ee5318c06becb3311e524534f78920c791f386fe417f55d04b256f",
-    "git_hash": "76e4e4a0a83bb4bf0dd5895e00f6c27d0ea02c19"
-  },
-  {
-    "date": "2023-01-26",
-    "version": "2.1.3-rc.5-arm64",
-    "container_hash": "e9774c0af96556ded86abcd77537d6dfe2385c830aae5360bd7743ea5f646a05",
-    "git_hash": "b390ba6416b65e545b3c8b687f0cfa83c77d2360"
-  },
-  {
-    "date": "2023-01-27",
-    "version": "2.1.3-rc.5-amd64",
-    "container_hash": "75df0ef5f0e0d335f11dfe7de3b72888c86d6bba80c91597dcf45e11a7d856ac",
-    "git_hash": "b390ba6416b65e545b3c8b687f0cfa83c77d2360"
   },
   {
     "date": "2023-01-31",
@@ -3985,48 +1761,6 @@
     "git_hash": "b43fd837a16a4ae4b236fa1ae80fbf595f813008"
   },
   {
-    "date": "2023-02-03",
-    "version": "2.2.1-rc.0-arm64",
-    "container_hash": "345bb77f875e956394907cbbd3d890e684ea8ee5804d6e7cbf845a16a20658f3",
-    "git_hash": "49a9c4dd0ac73e4a29cb4a5b7b7a88af2441abef"
-  },
-  {
-    "date": "2023-02-03",
-    "version": "2.2.1-rc.0-amd64",
-    "container_hash": "6d8310aff8894b7ce5f71b2e794c6854914e4a07d13e08758e78efa5b62c4af6",
-    "git_hash": "49a9c4dd0ac73e4a29cb4a5b7b7a88af2441abef"
-  },
-  {
-    "date": "2023-02-03",
-    "version": "2.2.1-rc.1-arm64",
-    "container_hash": "09a6858a6f8188c60562419e15eb55fe4111de206782db9d261050d0bffc634a",
-    "git_hash": "955c8ffad522094de7e0b2617a4843bcb0a16660"
-  },
-  {
-    "date": "2023-02-06",
-    "version": "2.2.1-rc.2-arm64",
-    "container_hash": "5bfaa5fadf8c101387fec831de1fb3fafb518254ee2cd6b7d076730b02929fa4",
-    "git_hash": "9b0d561eaee6ecccef4b9527a7706238bea8f5e9"
-  },
-  {
-    "date": "2023-02-06",
-    "version": "2.2.1-rc.2-amd64",
-    "container_hash": "fa7e3e4f3f12d4ae0ac84ec489c4e96b4e6de8e37cd9954708e48f3a602ac2b7",
-    "git_hash": "9b0d561eaee6ecccef4b9527a7706238bea8f5e9"
-  },
-  {
-    "date": "2023-02-06",
-    "version": "2.2.1-rc.3-arm64",
-    "container_hash": "205b2c0f5622c4dcf36b66d8bf6701d20322e7de44cdc5d70b1b450317297987",
-    "git_hash": "ed389ffd6aa1f11c82347e299a79cabec53b5f1b"
-  },
-  {
-    "date": "2023-02-06",
-    "version": "2.2.1-rc.3-amd64",
-    "container_hash": "dae44e40ce4bcaae69c4c8ec9bb2c9e630e6866c8f157f20924273500ccda999",
-    "git_hash": "ed389ffd6aa1f11c82347e299a79cabec53b5f1b"
-  },
-  {
     "date": "2023-02-07",
     "version": "2.1.0-arm64",
     "container_hash": "ff60d2d724e4609fca3854d01c654ac41740613552742226afc93836e2632786",
@@ -4129,54 +1863,6 @@
     "git_hash": "b43fd837a16a4ae4b236fa1ae80fbf595f813008"
   },
   {
-    "date": "2023-02-07",
-    "version": "2.2.1-rc.4-amd64",
-    "container_hash": "49feb312039b5139e7f1f3dfbb5ad162fe276f9136624ba32251f89e4a299c99",
-    "git_hash": "48e997dc6b725b535bb338568828b80d8eb73caf"
-  },
-  {
-    "date": "2023-02-07",
-    "version": "2.2.1-rc.4-arm64",
-    "container_hash": "2b96e6668ab3a6ffbe8b5f163327cb170bf670d68aa4a9201ecd96e2f66f24c1",
-    "git_hash": "48e997dc6b725b535bb338568828b80d8eb73caf"
-  },
-  {
-    "date": "2023-02-09",
-    "version": "2.2.1-rc.5-arm64",
-    "container_hash": "dc20ea434eb1a33255203b2c7bf86e7b4de8c3ae282c60a7272a45045eea52eb",
-    "git_hash": "a5ae1539f129b24f477d6782126313a95e7da8c5"
-  },
-  {
-    "date": "2023-02-09",
-    "version": "2.2.1-rc.5-amd64",
-    "container_hash": "37e93c57694f8f7cce058c97d8ed5144e565a71c52124043a455bcb6ce8d8d55",
-    "git_hash": "a5ae1539f129b24f477d6782126313a95e7da8c5"
-  },
-  {
-    "date": "2023-02-09",
-    "version": "2.2.1-rc.6-amd64",
-    "container_hash": "a986b72556ab2284ba1e922153029476671636e88676255bff024504cafb61b6",
-    "git_hash": "1e8772f24d6437bede00504264f633444387caac"
-  },
-  {
-    "date": "2023-02-09",
-    "version": "2.2.1-rc.6-arm64",
-    "container_hash": "d61960c712e0ef4d168c2c719572eed96f5d76a8b44e51ebb1ec5e51f35dadc8",
-    "git_hash": "1e8772f24d6437bede00504264f633444387caac"
-  },
-  {
-    "date": "2023-02-13",
-    "version": "2.2.1-rc.7-arm64",
-    "container_hash": "f194c2ddeb85347dba48626791c0c98bb4ec82cd4a2a2b0bf27bf88b2453050f",
-    "git_hash": "eb9fd4911925e342926c5421a25f820c777ec045"
-  },
-  {
-    "date": "2023-02-13",
-    "version": "2.2.1-rc.7-amd64",
-    "container_hash": "d1d1706c2791a4585fb19a90a97351a2a592b0ce2b56de6ec0c02793ac2faa18",
-    "git_hash": "eb9fd4911925e342926c5421a25f820c777ec045"
-  },
-  {
     "date": "2023-02-14",
     "version": "2.1.2-amd64",
     "container_hash": "30ac379491225c5d629ba3c1f5309a1b7ff03e8211df4e59de2417ea6f177f9e",
@@ -4277,30 +1963,6 @@
     "version": "2.1.1-arm64",
     "container_hash": "036fb4b1484308bb48809cea09dce159e91c155f2dfe668367287202c9c8100f",
     "git_hash": "b16966bfc003bb8d19fae78ee4e41c7a87f5e241"
-  },
-  {
-    "date": "2023-02-16",
-    "version": "2.2.1-rc.8-arm64",
-    "container_hash": "36e7a32cfadf0ea379fbdb1a17b94e00a279fce48bd0b7cfbf31c81318505b5e",
-    "git_hash": "7df4674652d50e6217db040eeb9266e4ab2991b3"
-  },
-  {
-    "date": "2023-02-16",
-    "version": "2.2.1-rc.8-amd64",
-    "container_hash": "d621c2530735bd2de78deb2e5e6c803aaca208cc51fd5cd542a893a66f9153fa",
-    "git_hash": "7df4674652d50e6217db040eeb9266e4ab2991b3"
-  },
-  {
-    "date": "2023-02-20",
-    "version": "2.2.1-rc.9-amd64",
-    "container_hash": "ab5d580d07ab129ad6f89e44a52a325ff695e3ee838296b30a935525b61f53d7",
-    "git_hash": "fa915775390fc50e993a6bf6e0f063477b990f59"
-  },
-  {
-    "date": "2023-02-20",
-    "version": "2.2.1-rc.9-arm64",
-    "container_hash": "221c591bd1a9427504c2e040a6956fab2ad1f7830fba6fd6a8292d19fb14a3bb",
-    "git_hash": "fa915775390fc50e993a6bf6e0f063477b990f59"
   },
   {
     "date": "2023-02-21",
@@ -4507,30 +2169,6 @@
     "git_hash": "b39f7704f51a0a38c4cd1dc3aea886291dc1e054"
   },
   {
-    "date": "2023-03-03",
-    "version": "2.2.1-rc.10-arm64",
-    "container_hash": "95f02d63adfe84c4e7c9537d43f4bb128d79634a3d713e49da1adaddd0bb865b",
-    "git_hash": "e370deb2627a2525c259ca53bfadc64eae2dd23d"
-  },
-  {
-    "date": "2023-03-03",
-    "version": "2.2.1-rc.10-amd64",
-    "container_hash": "6fb229654f4133a5f402b2a5ff9585ce9013990fbd77a6b70144ed8d277550cf",
-    "git_hash": "e370deb2627a2525c259ca53bfadc64eae2dd23d"
-  },
-  {
-    "date": "2023-03-03",
-    "version": "2.2.1-rc.11-amd64",
-    "container_hash": "bc8597175569ed328bf90360d77d253acd828f4b4fe5faac4d0da76b20851575",
-    "git_hash": "b5e3cb9b4fd3401070f19123dd8faf67cd546c37"
-  },
-  {
-    "date": "2023-03-03",
-    "version": "2.2.1-rc.11-arm64",
-    "container_hash": "e380daba543ae223be5d67c5833f1f157a3879da24c45ac9238f2b9dd41c80ef",
-    "git_hash": "b5e3cb9b4fd3401070f19123dd8faf67cd546c37"
-  },
-  {
     "date": "2023-03-07",
     "version": "1.1.2-arm64",
     "container_hash": "8a8e26d89065b01fea9d3edc12579e40f84700593786b034fd759ff2486dbed8",
@@ -4633,66 +2271,6 @@
     "git_hash": "442678ba34d42f1207c4c862e10d9e985464c226"
   },
   {
-    "date": "2023-03-13",
-    "version": "2.2.1-rc.12-arm64",
-    "container_hash": "0fba3cc2323bb484a1132b95cb3adaff8b0ab88909149aea9f5adbfb4a6c1997",
-    "git_hash": "c52ef00395cf02ed263ad90602f9c497037e12a6"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "2.2.1-rc.13-arm64",
-    "container_hash": "7e2ccd79dfaf79eac02862f44e34bb60e490ae310d6c0c434ddfd38f36df8eec",
-    "git_hash": "0fc59ac310978d8f67f34c05c7e86c176a2e82c2"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "2.2.1-rc.12-amd64",
-    "container_hash": "ab28f469e0b676c23cb93c61d9f18e90135e5f3d36ff41b40a20e2a5c39d6f92",
-    "git_hash": "c52ef00395cf02ed263ad90602f9c497037e12a6"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "2.2.1-rc.13-amd64",
-    "container_hash": "7eaea3de548b23f76197c33a44e4dba213163258ce873aa48dd18e2677cc26fa",
-    "git_hash": "0fc59ac310978d8f67f34c05c7e86c176a2e82c2"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "2.2.1-rc.14-amd64",
-    "container_hash": "d0a6fa6e030e1355920d58520a2ea13fa44502ee3920d36a8ddf68608ba6bb94",
-    "git_hash": "e7b95b1ed93f73f3dbcba3d59eb0759f70c77bbe"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "2.2.1-rc.15-amd64",
-    "container_hash": "39e7201d77271b2fbcf4fcf96299fa7bb95a9afd97775096b6cfb50271bcb2e1",
-    "git_hash": "82e3a81b2c4dec9074cbe2805a6100d35bb1d6d9"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "2.2.1-rc.16-amd64",
-    "container_hash": "ec66665c12a3fd0dd440930df4af7c6ee7ce5c64907963e7834176c18c8b7d0f",
-    "git_hash": "21ec6e5f783eead480cdb9268a7342ee1de855a5"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "2.2.1-rc.14-arm64",
-    "container_hash": "de4f08da0e85d0587d56653f7b64de3d00a4d80e63b477237d729631d2a432f6",
-    "git_hash": "e7b95b1ed93f73f3dbcba3d59eb0759f70c77bbe"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "2.2.1-rc.15-arm64",
-    "container_hash": "f278bb4b07a79aefa4f289adec5efebf14ba9c75cc8075f8bafea623d55795a1",
-    "git_hash": "82e3a81b2c4dec9074cbe2805a6100d35bb1d6d9"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "2.2.1-rc.16-arm64",
-    "container_hash": "b54d95bd78e5bf313fc3a2c89bc9e57603ecbd9ddd7ec41f47ed2c955d82d750",
-    "git_hash": "21ec6e5f783eead480cdb9268a7342ee1de855a5"
-  },
-  {
     "date": "2023-03-14",
     "version": "2.1.2-amd64",
     "container_hash": "1bf337aa8d304128501e119bc941511e152e4678558602793bd4100d8181be84",
@@ -4783,102 +2361,6 @@
     "git_hash": "b16966bfc003bb8d19fae78ee4e41c7a87f5e241"
   },
   {
-    "date": "2023-03-16",
-    "version": "2.2.1-rc.17-arm64",
-    "container_hash": "74d2946a890927378dc10acecac6ce1dba03b1b694a7241e1b37f51f01fc3611",
-    "git_hash": "68c323d2c97ceb07a068a85ea4df8cbd6e4a1e2d"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "2.2.1-rc.18-amd64",
-    "container_hash": "220d3b3d3f934bc9980ea0be1d8aab68d6bca4d46710172dbf7bdd52dd498061",
-    "git_hash": "8e14b430f676c6415a1e036a66f1d5857ef7dab7"
-  },
-  {
-    "date": "2023-03-16",
-    "version": "2.2.1-rc.18-arm64",
-    "container_hash": "7ba52aa4f72ef6f6e7b4fccd7b3e21a87b350aebb87ba7e8421ebad78cb063ad",
-    "git_hash": "8e14b430f676c6415a1e036a66f1d5857ef7dab7"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "2.2.1-rc.17-amd64",
-    "container_hash": "f8dbd2fa59c7c5bdf850a2cba5862027b4b3cc9d200d3da78bfc882a4bb44ab1",
-    "git_hash": "68c323d2c97ceb07a068a85ea4df8cbd6e4a1e2d"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "2.2.1-rc.19-amd64",
-    "container_hash": "59817e2c24971ba79f844e1c82c70708b355ee7f231bf53880c299bfc062dd12",
-    "git_hash": "e11a644e49311537b417a4c854c72a48d1230f8c"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "2.2.1-rc.20-amd64",
-    "container_hash": "478bf83b96b13791f310f74b6f234435a6280c1730bde57ab903319c1693a1d8",
-    "git_hash": "9f64f5850ad033ccf51cd9ae1857b6e28a879f3e"
-  },
-  {
-    "date": "2023-03-16",
-    "version": "2.2.1-rc.19-arm64",
-    "container_hash": "d1d6ffe1da938b09a0ed72db3c7e9f3e1547bcdd7a46da18dcf37c934ebd6a8e",
-    "git_hash": "e11a644e49311537b417a4c854c72a48d1230f8c"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "2.2.1-rc.21-amd64",
-    "container_hash": "9dea9f40236cc6b71e40181a7567f9d1c18c49b2e70c2e6c0437c21b7cc92701",
-    "git_hash": "7fc08216d8a2b813327470dee57f7c18d1f44c70"
-  },
-  {
-    "date": "2023-03-16",
-    "version": "2.2.1-rc.20-arm64",
-    "container_hash": "114ea3cf5e2ad3eacf6fadb707f8d3db96f0706d135afb8732b69dcf89163c12",
-    "git_hash": "9f64f5850ad033ccf51cd9ae1857b6e28a879f3e"
-  },
-  {
-    "date": "2023-03-16",
-    "version": "2.2.1-rc.21-arm64",
-    "container_hash": "31ca00d54b9d2675c5ac5b5707af23228a9ffecc2d0fb91d1d93d8f4cb7250fb",
-    "git_hash": "7fc08216d8a2b813327470dee57f7c18d1f44c70"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "2.2.1-rc.22-arm64",
-    "container_hash": "f756e3c6a092bb355e437e9fbb38e549c1a47fe72ea1eae1c31eacc81079833e",
-    "git_hash": "e7c4b03ece2c7091094804e980c300341ea3c453"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "2.2.1-rc.22-amd64",
-    "container_hash": "0d62b833ae0d8587145c47c0aef9efe620e4520f0053fe4b64510245ad549b0b",
-    "git_hash": "e7c4b03ece2c7091094804e980c300341ea3c453"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "2.2.1-rc.23-arm64",
-    "container_hash": "7994e3a132c1229acc8376511d1b0205c52f7a6f4e21eb61220c8b310fbf8f2d",
-    "git_hash": "1f2dce0fb3a0a0f108168114f7f686b4d99d7043"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "2.2.1-rc.24-arm64",
-    "container_hash": "43fdbdd2fb3a4542b36dd78c8ba086a138543e7b424ec68de2a326cbe9113674",
-    "git_hash": "ae4c814d86f6199cb7602012ce4f480f18dbfd99"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "2.2.1-rc.23-amd64",
-    "container_hash": "aa457de380ea3e11783fe4b8e9186bc39f999b8cd8d86b805a5e917486d0bf36",
-    "git_hash": "1f2dce0fb3a0a0f108168114f7f686b4d99d7043"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "2.2.1-rc.24-amd64",
-    "container_hash": "816df095979a3a7760cf20edc1ff4dbdfce900a57ef5937ad304db7ece5e05a2",
-    "git_hash": "ae4c814d86f6199cb7602012ce4f480f18dbfd99"
-  },
-  {
     "date": "2023-03-17",
     "version": "2.2.1-arm64",
     "container_hash": "77bfdc31ad1ec83c981c902b93be945b3503767842fc2972486df5a50ce2fb48",
@@ -4889,30 +2371,6 @@
     "version": "2.2.1-amd64",
     "container_hash": "91c649dfb5adcaef8d8f0d28ce2ec02526956f3d01cec8bad8a91efeeb475293",
     "git_hash": "630094a1e7c87629996f517b61ce16689bf386e4"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "2.2.2-rc.0-arm64",
-    "container_hash": "36398ceee41cb684b211dfc16551b8685141af71962c5a5bc1d82c847ca67e28",
-    "git_hash": "7182a0e7f29a17f3e4b22747d0d4067ccc96662b"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "2.2.2-rc.0-amd64",
-    "container_hash": "fbb7e26c97d680adcce03afd2b2f8248d7dfeed7d5eb482b016dfa702d34de68",
-    "git_hash": "7182a0e7f29a17f3e4b22747d0d4067ccc96662b"
-  },
-  {
-    "date": "2023-03-21",
-    "version": "2.2.2-rc.1-arm64",
-    "container_hash": "168dc55cbd5e4b6f9123f2ba1f1c4f30a5a235e4cd8e819b516969ded1aceb38",
-    "git_hash": "5c339ffab692d739889e3d4af03a6f0e7eecc072"
-  },
-  {
-    "date": "2023-03-21",
-    "version": "2.2.2-rc.1-amd64",
-    "container_hash": "b5c8ab7d27c4094748d400064a193a68438562a4ad8b90658434881c3edda6dc",
-    "git_hash": "5c339ffab692d739889e3d4af03a6f0e7eecc072"
   },
   {
     "date": "2023-03-21",
@@ -5057,66 +2515,6 @@
     "version": "2.1.1-amd64",
     "container_hash": "2f9126aec91fc4e5822a59e3b292e2c6b3fa304bd02e0bc9a9ccd670d3dae652",
     "git_hash": "b16966bfc003bb8d19fae78ee4e41c7a87f5e241"
-  },
-  {
-    "date": "2023-03-28",
-    "version": "2.2.2-rc.2-arm64",
-    "container_hash": "d2379926dee8df4450cfdcf340169c33b7649230bcf24255557f1f7124097875",
-    "git_hash": "551171d7ecffed99aa9325cc4337bf46707e0b71"
-  },
-  {
-    "date": "2023-03-28",
-    "version": "2.2.2-rc.2-amd64",
-    "container_hash": "b44f08604f944f743cf91c5f751af856271ec9d4b606f6dfd8acc38539284fee",
-    "git_hash": "551171d7ecffed99aa9325cc4337bf46707e0b71"
-  },
-  {
-    "date": "2023-03-28",
-    "version": "2.2.2-rc.3-amd64",
-    "container_hash": "9d3387ab4a299e362d4bfcc06d0eac2bf2a5ad5fbfa036b824a62370e4285efe",
-    "git_hash": "3db2202b9f6e133f4cbc0ffe213333bb9176ca0f"
-  },
-  {
-    "date": "2023-03-28",
-    "version": "2.2.2-rc.3-arm64",
-    "container_hash": "b172ddd0b38475246826c662463ae658b6a702e6d141483e333dd6141ab02347",
-    "git_hash": "3db2202b9f6e133f4cbc0ffe213333bb9176ca0f"
-  },
-  {
-    "date": "2023-03-31",
-    "version": "2.2.2-rc.5-amd64",
-    "container_hash": "14f02034703c5e4627f7004ce064c0f6b8bfbe16466708c9905de6580686b26a",
-    "git_hash": "ca5246eda62b4c2bca1c51008fa790f3b38b2ecd"
-  },
-  {
-    "date": "2023-03-31",
-    "version": "2.2.2-rc.5-arm64",
-    "container_hash": "c4129cafe1d8c907d5c50839f400dbbd5f646a6b0e0456019fe1d597515bd010",
-    "git_hash": "ca5246eda62b4c2bca1c51008fa790f3b38b2ecd"
-  },
-  {
-    "date": "2023-04-03",
-    "version": "2.2.2-rc.6-amd64",
-    "container_hash": "51d9372080b82550690ffa0dabf352868f550afadee8027f346d275d370db9ec",
-    "git_hash": "84636c823d04a07a6c020d6c840dc6a718b41e8f"
-  },
-  {
-    "date": "2023-04-03",
-    "version": "2.2.2-rc.6-arm64",
-    "container_hash": "a5397a93d316f97c7480eed1035e04dc79b37c169569ec9909cbaaa18fba9c2b",
-    "git_hash": "84636c823d04a07a6c020d6c840dc6a718b41e8f"
-  },
-  {
-    "date": "2023-04-03",
-    "version": "2.2.2-rc.7-amd64",
-    "container_hash": "ba72225480a767b1e743180f00651e4349c7da9c59b3201be426653b5ba1acbf",
-    "git_hash": "171697745e88248995517c9e1e3830ce80ed50ab"
-  },
-  {
-    "date": "2023-04-03",
-    "version": "2.2.2-rc.7-arm64",
-    "container_hash": "9cc068781ce81108e38e19b794bdad1e59a93924ac9f4366633aaaac270a57a6",
-    "git_hash": "171697745e88248995517c9e1e3830ce80ed50ab"
   },
   {
     "date": "2023-04-04",
@@ -5348,18 +2746,6 @@
   },
   {
     "date": "2023-04-13",
-    "version": "2.2.2-rc.8-amd64",
-    "container_hash": "ae51514345683436e0cc92fda6601fb69abcc4f7ffc801e41a4bd982f1c153d2",
-    "git_hash": "2b4a27f5eb24cc5ab0d34c854f1e9211c93b7cba"
-  },
-  {
-    "date": "2023-04-13",
-    "version": "2.2.2-rc.8-arm64",
-    "container_hash": "ca4a951b8c2e4a13961d94dca032425f05e1fc67ca51a9d716a54de1153e7cd1",
-    "git_hash": "2b4a27f5eb24cc5ab0d34c854f1e9211c93b7cba"
-  },
-  {
-    "date": "2023-04-13",
     "version": "2.3.0-amd64",
     "container_hash": "7684f3f10f86822f9682316c4ffc0e3242d484bf56ae8ae5d0dabf7234b0eaca",
     "git_hash": "1dd0dcdbbfd615b62639d8fb3e4809c1d26fba00"
@@ -5369,18 +2755,6 @@
     "version": "2.3.0-arm64",
     "container_hash": "8b0deb00860751cf855433205b5be5f4eb4c392486f72f549255c19ed4a27f42",
     "git_hash": "1dd0dcdbbfd615b62639d8fb3e4809c1d26fba00"
-  },
-  {
-    "date": "2023-04-14",
-    "version": "2.3.1-rc.0-amd64",
-    "container_hash": "19b68a81d10e2c904a9c38a52512fc9223ab477ef90e2ae1850d2797b8c97f08",
-    "git_hash": "a154414c70cc7924b45cf2775035451bcf22cb70"
-  },
-  {
-    "date": "2023-04-14",
-    "version": "2.3.1-rc.0-arm64",
-    "container_hash": "24d6606b7dca33ea5945ab039ccbd7f6a96eec4a4cca2f2aa1609c53f1cd13d2",
-    "git_hash": "a154414c70cc7924b45cf2775035451bcf22cb70"
   },
   {
     "date": "2023-04-18",
@@ -5593,18 +2967,6 @@
     "git_hash": "630094a1e7c87629996f517b61ce16689bf386e4"
   },
   {
-    "date": "2023-05-01",
-    "version": "2.3.1-rc.1-amd64",
-    "container_hash": "45b3ef3693d0c0aae8cf6fe37406bdccab6cef7e8d4102afd006b0892d17a88f",
-    "git_hash": "631346d1dcb26ef2fecaee58086aad9dd5fd6796"
-  },
-  {
-    "date": "2023-05-01",
-    "version": "2.3.1-rc.1-arm64",
-    "container_hash": "60802ad8080a2789a1d71de2632cf909da9c442fe72637678d4b09361c9a77a9",
-    "git_hash": "631346d1dcb26ef2fecaee58086aad9dd5fd6796"
-  },
-  {
     "date": "2023-05-02",
     "version": "2.1.0-arm64",
     "container_hash": "c5fb931e5043fe652d4668a5e20d193447bcc513dd27de028abeabde925ba4ca",
@@ -5689,18 +3051,6 @@
     "git_hash": "442678ba34d42f1207c4c862e10d9e985464c226"
   },
   {
-    "date": "2023-05-02",
-    "version": "2.4.0-rc.0-amd64",
-    "container_hash": "142d79ce248f9866a54afed2c0386ebd75555049e09268f8993b549a5f2b3c88",
-    "git_hash": "05906accc43f86909183d39cea4ed9376e84eed8"
-  },
-  {
-    "date": "2023-05-02",
-    "version": "2.4.0-rc.0-arm64",
-    "container_hash": "ef4fa38943c6f5f96d711d562ec7c8fccb86273d03c69ad3e100ab72f4ae49d3",
-    "git_hash": "05906accc43f86909183d39cea4ed9376e84eed8"
-  },
-  {
     "date": "2023-05-05",
     "version": "2.4.0-amd64",
     "container_hash": "c52bad8b02a775564d30ae3d40358f719eeee170558f209fc0034306847fd75c",
@@ -5711,42 +3061,6 @@
     "version": "2.4.0-arm64",
     "container_hash": "3393b93720f8b872087210836ba789f61b49b958e3be3c94a77ade3de5ef109b",
     "git_hash": "d1a314b2c579ef4cfe1a93a0d54f7a6bcef5fa96"
-  },
-  {
-    "date": "2023-05-23",
-    "version": "2.4.1-rc.0-amd64",
-    "container_hash": "440e18017da060adabd6aaddb7c33d9264fd6f88ec1e681effc10a675f503a08",
-    "git_hash": "75667f6c681791d69d8f1ca37f25d664bd2dbc7d"
-  },
-  {
-    "date": "2023-05-23",
-    "version": "2.4.1-rc.0-arm64",
-    "container_hash": "677dc1ed9d369878665ce68e39581a65e8599c930d30cfafb1ead42df75f86be",
-    "git_hash": "75667f6c681791d69d8f1ca37f25d664bd2dbc7d"
-  },
-  {
-    "date": "2023-06-08",
-    "version": "2.4.1-rc.1-amd64",
-    "container_hash": "f4802862485a374b92ff8098aa6bb7b4ecebb3e1cc579d3e93771920655140eb",
-    "git_hash": "a60f35d4cef65ca17707199ce37d68e76cdc9c1b"
-  },
-  {
-    "date": "2023-06-08",
-    "version": "2.4.1-rc.1-arm64",
-    "container_hash": "4a6ce28b39bdcb2dcb9c3339e70b47affe75d90a8ff25b20a1b012add8dd79e7",
-    "git_hash": "a60f35d4cef65ca17707199ce37d68e76cdc9c1b"
-  },
-  {
-    "date": "2023-08-17",
-    "version": "2.4.1-rc.2-amd64",
-    "container_hash": "cdd8c9b89e864fa2c134af3ddab1ded6cc20bd6553e2aee55a9c6dd2a3d12883",
-    "git_hash": "9ed51ca30e74b6a483ec3917c2a398cd1f224519"
-  },
-  {
-    "date": "2023-08-17",
-    "version": "2.4.1-rc.2-arm64",
-    "container_hash": "6c062a0b48bad5e8f7fe1fe0e34050e7c120ae0a9281d59f96b350fbf3132768",
-    "git_hash": "9ed51ca30e74b6a483ec3917c2a398cd1f224519"
   },
   {
     "date": "2023-12-07",

--- a/saas-shield-s3-proxy.json
+++ b/saas-shield-s3-proxy.json
@@ -265,79 +265,6 @@
     "git_hash": "948a0f6f0d5f9381d7e2a865f8191250c3f33d0f"
   },
   {
-    "version": "1.2.5-SNAPSHOT",
-    "container_hash": "6ca3b44a7394ce76500111520418f5771c86d5fe4abed64eaa94b217a6c5eb6e",
-    "git_hash": "740e810ba219808a361ff5aa5ee09450f3a667d9"
-  },
-  {
-    "version": "1.2.5-SNAPSHOT",
-    "container_hash": "77d2c4ccaed492485d56a4b190164a46022be630d29def7c746e009d8487e78c",
-    "git_hash": "87609144869ba982cf980b5a2e82d813ca14ed32"
-  },
-  {
-    "version": "1.2.5-pre.8",
-    "container_hash": "ff85c8bbd6ea8c7696942f9dc989bda8ff2d60ba844e6e6e93efdb922fbb03d3",
-    "git_hash": "66f0ed0bf38d4ce7e865bd53e7ae949ff5d12448"
-  },
-  {
-    "version": "1.2.5-pre.9",
-    "container_hash": "bc00643d8841cc5efb02e620b282452bf682281bb4c757b1e69e4f257fa0839f",
-    "git_hash": "08c4718e145c65307bffa59fbd05ec3ff2f0ec12"
-  },
-  {
-    "version": "1.2.5-rc.10",
-    "container_hash": "606b38acb7a1272502cd35fe64779044d6dc4a2522b78336daf79057cd89a091",
-    "git_hash": "1616df42f7e7a364cf380a3888398d6eee9740ff"
-  },
-  {
-    "version": "1.2.5-rc.11",
-    "container_hash": "aa0d54b2185aab4e708eee709802e7d592e2777647b24fdc8775381706127340",
-    "git_hash": "f9b3d29b0175c97881c5307457c307d0d18c84f7"
-  },
-  {
-    "version": "1.2.5-rc.12",
-    "container_hash": "0f4e3ec826029f3dabda3ffa62be4719782e68d621d632d07c7140d5ff88c917",
-    "git_hash": "258318ac75e8f17423d167c0ef0c64cfc912d500"
-  },
-  {
-    "version": "1.2.5-rc.13",
-    "container_hash": "f95ba11e9b762c771a2949e2a05fed18e013b74626a400a23378060b7879639e",
-    "git_hash": "8592016d70aa1fa2b109c8748e9cb24a33eb68b6"
-  },
-  {
-    "version": "1.2.5-rc.14",
-    "container_hash": "bb510e0337c71743cee4b300ac418f484c44e2486d34ce3a76845d309c9bb7a2",
-    "git_hash": "bcccace9280261cb31a75b773e586ecba22d159e"
-  },
-  {
-    "version": "1.2.5-rc.15",
-    "container_hash": "55bfed8807ed6ba2b2cec2eb7ceda7a581c9bb7ad6b3ebd5c1cb841b20ace589",
-    "git_hash": "699c692bf2e07ea6ddb9905cffd6d8c4b8f3ee52"
-  },
-  {
-    "version": "1.2.5-rc.9",
-    "container_hash": "c0b9b63d65a4c67f9986210bf7fef4145478108af24140413ab03fbff1c4fe10",
-    "git_hash": "2b2f509b03f138d9f195e4f559caeed33d792202"
-  },
-  {
-    "date": "2022-04-08",
-    "version": "1.2.5-rc.16",
-    "container_hash": "adc865fd6d3dd70bfcf396b504ab1cacda0f6763a23a72461e07f41110ff4d82",
-    "git_hash": "eef1195906b4d03506455dedfc3b9d8724178f86"
-  },
-  {
-    "date": "2022-04-08",
-    "version": "pr-186-Add-rebuild-workflow-and-update",
-    "container_hash": "5bf918d347466858af2105eceb49d0e047f8675ec24a4aa1dc283a183009171a",
-    "git_hash": "7713a3ab2e40c598bd78a04ddc5b4d3e4f0e6824"
-  },
-  {
-    "date": "2022-04-18",
-    "version": "1.2.5-rc.17",
-    "container_hash": "7295bc9bcf7146d97b471afe591ffb84bbdde897eaea6f5ee2259efc7115a78a",
-    "git_hash": "bb5d1c295db94a0287d7b67b2a59d19c18d2bf18"
-  },
-  {
     "date": "2022-04-19",
     "version": "1.1.1",
     "container_hash": "d2964f617892f5c101f9c23ff2a5c29d94a98e3913aa7f169a5770208689bd71",
@@ -398,12 +325,6 @@
     "git_hash": "3060cc9790478e24e6ddf53fa5083fbc5f13a65e"
   },
   {
-    "date": "2022-04-25",
-    "version": "1.2.5-rc.18",
-    "container_hash": "9ea94cc0daa865d100d35386169729952d38d549a04314807f3af3825a5f1271",
-    "git_hash": "174e1bdcb95e19452c01c27f241776fcf7a6a019"
-  },
-  {
     "date": "2022-04-26",
     "version": "1.1.1",
     "container_hash": "78503d2f7530d3199f9c5c7e9a58d2ed19c4865e5403803f74d3cab730cfef7c",
@@ -450,18 +371,6 @@
     "version": "1.1.0",
     "container_hash": "91d61a808adab1dd6047f82f53fb6ee44c4a7099fb7eb8b6cee4878a4a4437cd",
     "git_hash": "3e09eb7c7567943aacb62ca15406fc6392c5a278"
-  },
-  {
-    "date": "2022-04-27",
-    "version": "1.2.5-rc.19",
-    "container_hash": "067f21a8420d90db8d83072293b6846ac1caeb793e217b15060e07c71d538721",
-    "git_hash": "fc46f970ef1c1ff5fda0d44459451a247391945c"
-  },
-  {
-    "date": "2022-05-02",
-    "version": "1.2.5-rc.110",
-    "container_hash": "72287adb30a20771bb24e2517f7cfcdcb10c34cb9ffdc95396d66514a28ae185",
-    "git_hash": "f74d19230da8a37fc1717b599d729e1beacc77a2"
   },
   {
     "date": "2022-05-03",
@@ -512,12 +421,6 @@
     "git_hash": "212b32c68e9765471f20a6d0cef1e15162eacd69"
   },
   {
-    "date": "2022-05-09",
-    "version": "1.2.5-rc.111",
-    "container_hash": "42a34eded62fed05dffb6eb389ab84a9ce79d523eec1f0fa85c6d3c3fceba776",
-    "git_hash": "6acac9daeda1f2bbe18bf95235bc306b00e16446"
-  },
-  {
     "date": "2022-05-10",
     "version": "1.1.0",
     "container_hash": "a04c49284378d195efaa48404e4a0a575d1d6881b22ef7a0640a77ac115538d2",
@@ -566,12 +469,6 @@
     "git_hash": "40d2e68d2505d4d7847ecc6da935d371907332ba"
   },
   {
-    "date": "2022-05-16",
-    "version": "1.2.5-rc.112",
-    "container_hash": "c57e26db1a18bb39cf99be03adb23a7a38c8e9baafd6ad9d62be9bda8f03bfb0",
-    "git_hash": "ce008cd138aa08363751af9aa3666b1eb365e330"
-  },
-  {
     "date": "2022-05-17",
     "version": "1.1.0",
     "container_hash": "90927329de83e7bc0843b3ecd4d35170e0f29dec321fa84f3f51c38d3062a566",
@@ -618,12 +515,6 @@
     "version": "1.1.1",
     "container_hash": "9af2fce2190b43bf8c88db1255e223f53ef359a18f8fd3ad255d62b1e49490d8",
     "git_hash": "d9fba3a811d40b4c6bc1feb42e19d686416c639a"
-  },
-  {
-    "date": "2022-05-23",
-    "version": "1.2.5-rc.113",
-    "container_hash": "bd0d23e6fe2114097e7ef0872d6e2c6853d0ce8f7358b6a1fe2016295924e2d7",
-    "git_hash": "43b496703c6ea20d9241d85efac14a316d8176d2"
   },
   {
     "date": "2022-05-24",
@@ -722,24 +613,6 @@
     "git_hash": "40d2e68d2505d4d7847ecc6da935d371907332ba"
   },
   {
-    "date": "2022-06-01",
-    "version": "1.2.5-rc.114",
-    "container_hash": "d7c21de4283227ed52852ab205af4673dce8a6d4718d127e442eb8bdc8fb1c07",
-    "git_hash": "c41beb20f01af364123a85c40b76896fdfb1501a"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "1.2.5-rc.115-amd64",
-    "container_hash": "6002218c1af98ad4ceb377221c1e0af3095b851f2ac9b484360e1dc7b7e887e3",
-    "git_hash": "24d595fac049dae95e4958ab11f2c09c57780f34"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "1.2.5-rc.115-arm64",
-    "container_hash": "a906e6878edd35777d177cae238297013f9fbbb0821d888a9a0ce6b5afcceec4",
-    "git_hash": "24d595fac049dae95e4958ab11f2c09c57780f34"
-  },
-  {
     "date": "2022-06-03",
     "version": "1.2.5-amd64",
     "container_hash": "6ca7dd5f1c97f424e4ab83a38da6117ed11156c5f8ba95142f68d78d33f3c4de",
@@ -750,18 +623,6 @@
     "version": "1.2.5-arm64",
     "container_hash": "02d9bde9e720ce390534fe4458b94e0ea854de4541c958784e400baab3b33b0e",
     "git_hash": "2bea2b5e5a4f6d2d8f41790eb25889455dc48f3e"
-  },
-  {
-    "date": "2022-06-06",
-    "version": "1.2.6-rc.0-amd64",
-    "container_hash": "8dddf7cffdf7d1ac0e221a17b9e242427b2f52e133498fe72c719f257d385966",
-    "git_hash": "2146e549c1e40a82cd425c6e21712f900ba3f625"
-  },
-  {
-    "date": "2022-06-06",
-    "version": "1.2.6-rc.0-arm64",
-    "container_hash": "a3a805c7db501c63415d8df52998bb30f90f2ddf2ad5a35cb7855b379f58e989",
-    "git_hash": "2146e549c1e40a82cd425c6e21712f900ba3f625"
   },
   {
     "date": "2022-06-07",
@@ -824,18 +685,6 @@
     "git_hash": "2bea2b5e5a4f6d2d8f41790eb25889455dc48f3e"
   },
   {
-    "date": "2022-06-13",
-    "version": "1.2.6-rc.1-amd64",
-    "container_hash": "88e017734a97750811f33602ede67eb7459c518a10047d0de9a3d7ce419edb08",
-    "git_hash": "f2a3e8dacb8e27208423bd99b67a60b2663c0a67"
-  },
-  {
-    "date": "2022-06-13",
-    "version": "1.2.6-rc.1-arm64",
-    "container_hash": "05a51300cb265550b52236babca738fb261eaca66a461639de030d8ad514a40a",
-    "git_hash": "f2a3e8dacb8e27208423bd99b67a60b2663c0a67"
-  },
-  {
     "date": "2022-06-14",
     "version": "1.1.1-amd64",
     "container_hash": "5eddc79c68dca1b4c7fbd32b7a605312152f835dce98385dc404cd4496a36a39",
@@ -890,42 +739,6 @@
     "git_hash": "2bea2b5e5a4f6d2d8f41790eb25889455dc48f3e"
   },
   {
-    "date": "2022-06-14",
-    "version": "jre-not-jdk-arm64",
-    "container_hash": "d762bf85120d3f9bf3c8fca4229c97ec36b636ee083f3168d7a544d04049d6d2",
-    "git_hash": "3005b024aebe4b1e61404e2b309358feb142c262"
-  },
-  {
-    "date": "2022-06-14",
-    "version": "jre-not-jdk-amd64",
-    "container_hash": "071a7055b064564cd4e051423ddbf59cd889d764a5958cd87feb92cae1faafb7",
-    "git_hash": "3005b024aebe4b1e61404e2b309358feb142c262"
-  },
-  {
-    "date": "2022-06-14",
-    "version": "1.2.6-rc.2-amd64",
-    "container_hash": "586d2e455d3fceebe5210047a6530e1a963fdb12651a0e182c9ea7461f640ef4",
-    "git_hash": "96eabf98ee86deb66b4dcfdfec9a2e1a6344bb90"
-  },
-  {
-    "date": "2022-06-14",
-    "version": "1.2.6-rc.2-arm64",
-    "container_hash": "76828b21cf11f9fc97718f8a36679aaaa1a702b23a6a5be63a8f8447f4b6c86d",
-    "git_hash": "96eabf98ee86deb66b4dcfdfec9a2e1a6344bb90"
-  },
-  {
-    "date": "2022-06-17",
-    "version": "1.2.6-rc.3-arm64",
-    "container_hash": "d21c2aefcee17b9c6e6383c99382f2583cb819f7c951933c290a5b590b42a02d",
-    "git_hash": "c41b5771fbe847dce656822b148148028c3752c4"
-  },
-  {
-    "date": "2022-06-17",
-    "version": "1.2.6-rc.3-amd64",
-    "container_hash": "b931c9539ffc16bc6fc450e3e99d88a01b9b35951d09be5e312a662fad727779",
-    "git_hash": "c41b5771fbe847dce656822b148148028c3752c4"
-  },
-  {
     "date": "2022-06-17",
     "version": "1.2.6-arm64",
     "container_hash": "92700ee681ca35fc4696512f0d99a6c70bddb81fb707db96c4ad2f7eb62776f6",
@@ -936,18 +749,6 @@
     "version": "1.2.6-amd64",
     "container_hash": "64d9c42baf0d0eec8c4192c238f8fec22cc2a645adb81e39c455370c84862e95",
     "git_hash": "9b8ff9d2230bfc369431b45ed7b714cc61b3c94c"
-  },
-  {
-    "date": "2022-06-20",
-    "version": "1.2.7-rc.0-arm64",
-    "container_hash": "0a6c5507d999a318bc6f836b40518477cce0a0ceadc8b0b4122c12dfdc2f4122",
-    "git_hash": "e9c38f7d851441e9d843148d5d7b24abade0b428"
-  },
-  {
-    "date": "2022-06-20",
-    "version": "1.2.7-rc.0-amd64",
-    "container_hash": "1eb3be3606f6e13cb6d92cce1dd5bd9114d0caff7c6140c93f2c5e568dadd62b",
-    "git_hash": "e9c38f7d851441e9d843148d5d7b24abade0b428"
   },
   {
     "date": "2022-06-21",
@@ -1070,18 +871,6 @@
     "git_hash": "c942b7f7bdb05eff329a730aec3546b3cadc5e6f"
   },
   {
-    "date": "2022-07-04",
-    "version": "1.2.7-rc.1-amd64",
-    "container_hash": "e8a59f40ebc89a9654eb2a5a828171e0b0bd0177d7788e132dbcf97d01898d32",
-    "git_hash": "f0dc67b94240e696ae27d2a6bd7f8b5578aa84cd"
-  },
-  {
-    "date": "2022-07-04",
-    "version": "1.2.7-rc.1-arm64",
-    "container_hash": "b09c605b14479c822bdcefc536870eadaee26d1b8fc03e60013fe61511a70e69",
-    "git_hash": "f0dc67b94240e696ae27d2a6bd7f8b5578aa84cd"
-  },
-  {
     "date": "2022-07-05",
     "version": "1.2.6-arm64",
     "container_hash": "e5afd125372ce0be5f0b6cdaca2eb1ba5d13079bad6312d94c951e1eb85bc1d9",
@@ -1092,18 +881,6 @@
     "version": "1.2.6-amd64",
     "container_hash": "0bc500f1c9c517c79539f81f065d0d602cfc529e3a2ea80c0da80876423efd3d",
     "git_hash": "9b8ff9d2230bfc369431b45ed7b714cc61b3c94c"
-  },
-  {
-    "date": "2022-07-11",
-    "version": "1.2.7-rc.2-amd64",
-    "container_hash": "c97e57c3acd62352fbdd421790106855c63e52f1c998cdab2b598a5671e52251",
-    "git_hash": "89e7c811e6971dc5520dea8bfd629aceaf91ac0c"
-  },
-  {
-    "date": "2022-07-11",
-    "version": "1.2.7-rc.2-arm64",
-    "container_hash": "f457fef562650ffb6b65b5821c4196f648fdaa8cf879cbc19679ba67cb62ba51",
-    "git_hash": "89e7c811e6971dc5520dea8bfd629aceaf91ac0c"
   },
   {
     "date": "2022-07-12",
@@ -1178,30 +955,6 @@
     "git_hash": "2fd175cfa1a0637b6a1056ccbbe43c7c2f1cb513"
   },
   {
-    "date": "2022-08-10",
-    "version": "1.2.7-rc.3-amd64",
-    "container_hash": "8b02c1aaaffeb1b8c392844751885873bde2400a998a97c870fa56aaab796e8f",
-    "git_hash": "84c0adbc190be75aa22c056fec7d0fa44be00d65"
-  },
-  {
-    "date": "2022-08-10",
-    "version": "1.2.7-rc.3-arm64",
-    "container_hash": "11b27f87ba0dceda27121c7273b92fa1d0da5394f07a372dd5948515fa403493",
-    "git_hash": "84c0adbc190be75aa22c056fec7d0fa44be00d65"
-  },
-  {
-    "date": "2022-08-15",
-    "version": "1.2.7-rc.4-amd64",
-    "container_hash": "040f7865611e4d2b76882ee64d7a94a7e27fd3b77036ce6e83de99b0598af4ae",
-    "git_hash": "48ab8b0ef8ce76fd4ec4b7fb8de26e54d99489f2"
-  },
-  {
-    "date": "2022-08-15",
-    "version": "1.2.7-rc.4-arm64",
-    "container_hash": "1438931bd6cd3951109acadea004540d88abed5f41757bfb9fa7e5e4793df0d3",
-    "git_hash": "48ab8b0ef8ce76fd4ec4b7fb8de26e54d99489f2"
-  },
-  {
     "date": "2022-08-16",
     "version": "1.2.6-arm64",
     "container_hash": "670d52ef2a57a3a964fe751fb988b500a9a552204e10ba3e27d88151f7d71b18",
@@ -1224,18 +977,6 @@
     "version": "1.2.6-amd64",
     "container_hash": "72d0aad93ebc98eea1afe53470c82eddd1f772502d4044a9838eb63b9be08ad6",
     "git_hash": "2fd175cfa1a0637b6a1056ccbbe43c7c2f1cb513"
-  },
-  {
-    "date": "2022-08-29",
-    "version": "1.2.7-rc.5-arm64",
-    "container_hash": "c732010ba972f6220fbe4fd0b8c127e36b7c2bd952eed4815c153ef337f0b18e",
-    "git_hash": "e71708b18f327354b2f169b68ef521d77f92bc77"
-  },
-  {
-    "date": "2022-08-29",
-    "version": "1.2.7-rc.5-amd64",
-    "container_hash": "ea60e51cb1393528945deb07fe376068f7c5b5d3eee7099fe5d910a6749923e9",
-    "git_hash": "e71708b18f327354b2f169b68ef521d77f92bc77"
   },
   {
     "date": "2022-08-30",
@@ -1262,42 +1003,6 @@
     "git_hash": "2fd175cfa1a0637b6a1056ccbbe43c7c2f1cb513"
   },
   {
-    "date": "2022-09-07",
-    "version": "1.2.7-rc.6-arm64",
-    "container_hash": "63d1c13cd0c177f19dbc305ef260dde910252e308ee17d1748de28392f1359ef",
-    "git_hash": "591ec946658eef109783016034e216d4248fbc63"
-  },
-  {
-    "date": "2022-09-07",
-    "version": "1.2.7-rc.6-amd64",
-    "container_hash": "f13dadc40be455266a4042662fb3446a917a1e6312644b876f1884c170414c16",
-    "git_hash": "591ec946658eef109783016034e216d4248fbc63"
-  },
-  {
-    "date": "2022-09-08",
-    "version": "1.2.7-rc.7-amd64",
-    "container_hash": "472ae166ce347aa118e504c520c78b6f0f7f575d1e8a700192c0afedfbed9772",
-    "git_hash": "dbb4c0388d207bab2202e41dbb6ecb0cea7258ab"
-  },
-  {
-    "date": "2022-09-08",
-    "version": "1.2.7-rc.7-arm64",
-    "container_hash": "e303d815379dfd21804bf009ec17d87d80c6d91982ca13d3d641da545727e94f",
-    "git_hash": "dbb4c0388d207bab2202e41dbb6ecb0cea7258ab"
-  },
-  {
-    "date": "2022-09-12",
-    "version": "1.2.7-rc.8-amd64",
-    "container_hash": "d7636992721b9bdc48acaf0bd4466f450bfbbb76465fe812bd0b1b5f570c1080",
-    "git_hash": "cb57afc09fadcc576f7ca5f821cbf3555ceb685a"
-  },
-  {
-    "date": "2022-09-12",
-    "version": "1.2.7-rc.8-arm64",
-    "container_hash": "9680c0bb460b1e0c2d550ab783e52254c96c1be0abc9ae3746ed15e795023237",
-    "git_hash": "cb57afc09fadcc576f7ca5f821cbf3555ceb685a"
-  },
-  {
     "date": "2022-09-13",
     "version": "1.2.6-arm64",
     "container_hash": "87d70b454e63637b5ac67b5cc799511dcfa426136f28068faab67df913da3739",
@@ -1308,18 +1013,6 @@
     "version": "1.2.6-amd64",
     "container_hash": "481308a194dde99e1f2e85d342db1906d34e0e24eb32e107067152040ac53b82",
     "git_hash": "2fd175cfa1a0637b6a1056ccbbe43c7c2f1cb513"
-  },
-  {
-    "date": "2022-09-19",
-    "version": "1.2.7-rc.9-arm64",
-    "container_hash": "06144dfcb95c5842c33c57483b3c024f5160bdb66dfc8e74e51a8dac33858e01",
-    "git_hash": "433f806eed4e0eebf0d2f2fa8471d65dee69aab2"
-  },
-  {
-    "date": "2022-09-19",
-    "version": "1.2.7-rc.9-amd64",
-    "container_hash": "79a91f037c27c4944ac93740cd7cec21a42988d6850c8b1bd32ce37f0a57a2c8",
-    "git_hash": "433f806eed4e0eebf0d2f2fa8471d65dee69aab2"
   },
   {
     "date": "2022-09-20",
@@ -1334,30 +1027,6 @@
     "git_hash": "2fd175cfa1a0637b6a1056ccbbe43c7c2f1cb513"
   },
   {
-    "date": "2022-09-22",
-    "version": "1.2.7-rc.10-amd64",
-    "container_hash": "0b50685a25fe0ffe2bf7d6e95119f0383a0f66ec56150bc6ca95c834b90aca86",
-    "git_hash": "06d1821a9d9dd55ec53285dda36e5e0775eaf530"
-  },
-  {
-    "date": "2022-09-22",
-    "version": "1.2.7-rc.10-arm64",
-    "container_hash": "32e72a9070acbb0c5b34d7d34d66ab6d22d8b0285e6b106f70d532f1995d4cca",
-    "git_hash": "06d1821a9d9dd55ec53285dda36e5e0775eaf530"
-  },
-  {
-    "date": "2022-09-26",
-    "version": "1.2.7-rc.11-arm64",
-    "container_hash": "2e3aa8f09b09a6ba6cbbd7c80a243ebea2cb42d5cb4eff36aeb14bc8706c85d7",
-    "git_hash": "d70e8c0dd80acc07e706f87da8d15733cdb498d8"
-  },
-  {
-    "date": "2022-09-26",
-    "version": "1.2.7-rc.11-amd64",
-    "container_hash": "59f035c401163ff2a1ba1e066880e37e5dce7ed6251ca8e3c8702745fc1af145",
-    "git_hash": "d70e8c0dd80acc07e706f87da8d15733cdb498d8"
-  },
-  {
     "date": "2022-09-27",
     "version": "1.2.6-arm64",
     "container_hash": "5d787356be9c440cfc0f7d790b0f7139cc5ac51669f1dd84b455148f61a14152",
@@ -1368,18 +1037,6 @@
     "version": "1.2.6-amd64",
     "container_hash": "8dce21cdfde10c71ca0bab63c7e960217250b14b0c63a3f9defcb581e2d288d9",
     "git_hash": "2fd175cfa1a0637b6a1056ccbbe43c7c2f1cb513"
-  },
-  {
-    "date": "2022-10-03",
-    "version": "1.2.7-rc.12-amd64",
-    "container_hash": "674566dde804453b5d250f39e56fa9465588d266e2e4441c31571012d1b5db74",
-    "git_hash": "a9153d184ec98a7e751f6c66908295d40ec25ecc"
-  },
-  {
-    "date": "2022-10-03",
-    "version": "1.2.7-rc.12-arm64",
-    "container_hash": "7a5c2f594464ca1d845af66c6ac212ef0bc2bdd185623dc1f11072da04b8ed90",
-    "git_hash": "a9153d184ec98a7e751f6c66908295d40ec25ecc"
   },
   {
     "date": "2022-10-04",
@@ -1394,18 +1051,6 @@
     "git_hash": "2fd175cfa1a0637b6a1056ccbbe43c7c2f1cb513"
   },
   {
-    "date": "2022-10-10",
-    "version": "1.2.7-rc.13-amd64",
-    "container_hash": "3731ee355bdadb067752bc1cd8775d07dadb5dde9068212eb69c2098dd16eb2b",
-    "git_hash": "f2a7d818d5e7efa75e011aeb53b5ebb46f2c3088"
-  },
-  {
-    "date": "2022-10-10",
-    "version": "1.2.7-rc.13-arm64",
-    "container_hash": "41a450a7a888d739e4270ca76c738e986c17241964a328bad728e40b15ebb727",
-    "git_hash": "f2a7d818d5e7efa75e011aeb53b5ebb46f2c3088"
-  },
-  {
     "date": "2022-10-11",
     "version": "1.2.6-arm64",
     "container_hash": "ff0943e79a5f88dea741155357157fcb00e71dff457370d5e41ffd22c2cf4e9a",
@@ -1416,12 +1061,6 @@
     "version": "1.2.6-amd64",
     "container_hash": "8013f029915a4413045de8bfb25e6ba0f12644fd20244e284616349bbb5b9137",
     "git_hash": "2fd175cfa1a0637b6a1056ccbbe43c7c2f1cb513"
-  },
-  {
-    "date": "2022-10-17",
-    "version": "1.2.7-rc.14-amd64",
-    "container_hash": "df74a37cf18f3f0af35cd187128137c93ade30d7517f493e2936d7ea5183f6a5",
-    "git_hash": "44a45c3066dbc51cbd2c4e473d139ba8ffcf4f77"
   },
   {
     "date": "2022-10-18",
@@ -1508,18 +1147,6 @@
     "git_hash": "2fd175cfa1a0637b6a1056ccbbe43c7c2f1cb513"
   },
   {
-    "date": "2022-12-05",
-    "version": "1.2.7-rc.15-amd64",
-    "container_hash": "379373dba11648703b3d93e620822e0ff3196c5fb77b8ece282078d2ee588a34",
-    "git_hash": "3f33f491be024db2141e226b1f58201d0cd6c758"
-  },
-  {
-    "date": "2022-12-05",
-    "version": "1.2.7-rc.15-arm64",
-    "container_hash": "74d6abf657ab2678f16d3e90e6b17940070abc48c6b8d3e0460fb7e90c7d1a26",
-    "git_hash": "3f33f491be024db2141e226b1f58201d0cd6c758"
-  },
-  {
     "date": "2022-12-06",
     "version": "1.2.6-arm64",
     "container_hash": "68c99b67b63d8325c8613aaa67dabe5cb34f40dcd037901e7191422a39602349",
@@ -1544,18 +1171,6 @@
     "git_hash": "2fd175cfa1a0637b6a1056ccbbe43c7c2f1cb513"
   },
   {
-    "date": "2023-01-06",
-    "version": "1.2.7-rc.16-arm64",
-    "container_hash": "ee35cb9bb2626af5c149ef189f070d10f38797d272b1dcea7fc906193506f976",
-    "git_hash": "7756adc7421d8a1ab944a97b40950987734fba95"
-  },
-  {
-    "date": "2023-01-06",
-    "version": "1.2.7-rc.16-amd64",
-    "container_hash": "380d5c2157a71e32c1018ce8a2fceec2b91543a0233d2ecfcf18b396f5531037",
-    "git_hash": "7756adc7421d8a1ab944a97b40950987734fba95"
-  },
-  {
     "date": "2023-01-10",
     "version": "1.2.6-arm64",
     "container_hash": "beb5bc8f165b72d4f1c840db9517dc10f649b5f191d9c0517cdbda7d54e97ff5",
@@ -1568,12 +1183,6 @@
     "git_hash": "2fd175cfa1a0637b6a1056ccbbe43c7c2f1cb513"
   },
   {
-    "date": "2023-01-16",
-    "version": "1.2.7-rc.17-amd64",
-    "container_hash": "1b05d5c91e31e2bc93f29a79519d1a44168b3db4f016a9b1a7ab1dc1253b4d2e",
-    "git_hash": "908f58f309da09f3abdd31d532fe0d66294d478a"
-  },
-  {
     "date": "2023-01-17",
     "version": "1.2.6-arm64",
     "container_hash": "f5e7e39b629e07dafafb33d24d818e27b12ecd8523f2add12ecfb432469ce0a2",
@@ -1584,18 +1193,6 @@
     "version": "1.2.6-amd64",
     "container_hash": "afe29dcea091d063ba269f0860ccc6e92d9a24b638b03b430279c22adc1f1d96",
     "git_hash": "2fd175cfa1a0637b6a1056ccbbe43c7c2f1cb513"
-  },
-  {
-    "date": "2023-01-18",
-    "version": "1.2.7-rc.18-arm64",
-    "container_hash": "15a6cc87339c481bfab899698f578bf34a6d45a9623112d4dfa66e87f7043c3c",
-    "git_hash": "d36c61c81f113b63b8127358dc2897964032c354"
-  },
-  {
-    "date": "2023-01-18",
-    "version": "1.2.7-rc.18-amd64",
-    "container_hash": "5784065fcbcd79d744fdae9e852f6608e7220969d1b8835fc0cfaaa4b8ee6882",
-    "git_hash": "d36c61c81f113b63b8127358dc2897964032c354"
   },
   {
     "date": "2023-01-24",
@@ -1622,12 +1219,6 @@
     "git_hash": "2fd175cfa1a0637b6a1056ccbbe43c7c2f1cb513"
   },
   {
-    "date": "2023-02-06",
-    "version": "1.2.7-rc.19-amd64",
-    "container_hash": "c765bd5f61c5a40b7155b58761618e078a3f6733e37ee1c0fa7a565e11016c0e",
-    "git_hash": "f114e0d4e70b9a245d6900fdec3f678db8dbebec"
-  },
-  {
     "date": "2023-02-07",
     "version": "1.2.6-arm64",
     "container_hash": "0bfb570e3eaa19fa98827f58ca9137b69d742abfaa1e2a310763e47021e09cf3",
@@ -1638,24 +1229,6 @@
     "version": "1.2.6-amd64",
     "container_hash": "e5fa64019d98e7bda9be001b884d222d0223ca51f4c496c1db5080af9fb7fc49",
     "git_hash": "2fd175cfa1a0637b6a1056ccbbe43c7c2f1cb513"
-  },
-  {
-    "date": "2023-02-11",
-    "version": "1.2.7-rc.20-amd64",
-    "container_hash": "1c87cee8b130a11b758bc211f675c9328f6c3753e282d6197af53c473897b43d",
-    "git_hash": "67473a7baf4ba7378dbc9a79a5efce9c1b4fe6f7"
-  },
-  {
-    "date": "2023-02-10",
-    "version": "1.2.7-rc.20-arm64",
-    "container_hash": "6e0950632347013482cb6b94538c62bae3cfd03f515b11dcbba9cc60fb1ebc1a",
-    "git_hash": "67473a7baf4ba7378dbc9a79a5efce9c1b4fe6f7"
-  },
-  {
-    "date": "2023-02-13",
-    "version": "1.2.7-rc.21-amd64",
-    "container_hash": "337e8decf27fd7eaf1da271f816342ae2a028e0fc2bbd94695907dbe5a6c2ab2",
-    "git_hash": "bedc7b46713dfe62d8d3789409386e0a92276720"
   },
   {
     "date": "2023-02-14",
@@ -1670,12 +1243,6 @@
     "git_hash": "2fd175cfa1a0637b6a1056ccbbe43c7c2f1cb513"
   },
   {
-    "date": "2023-02-20",
-    "version": "1.2.7-rc.22-amd64",
-    "container_hash": "180f1a079559783631fd7fc7f28c07927057ef469829b1587f3acbf8f8aa5213",
-    "git_hash": "2d01b75b59f616075236f7f293a8aef7cbaa0a7b"
-  },
-  {
     "date": "2023-02-21",
     "version": "1.2.6-arm64",
     "container_hash": "bc3e03289238c7fbf725776acbb682b6cb686d8433ff464147de31ab83641293",
@@ -1686,12 +1253,6 @@
     "version": "1.2.6-amd64",
     "container_hash": "2f65fdd7757f84763d30b79fc0bbc41104df75116771ced3bac1e3f3919dfc28",
     "git_hash": "2fd175cfa1a0637b6a1056ccbbe43c7c2f1cb513"
-  },
-  {
-    "date": "2023-02-27",
-    "version": "1.2.7-rc.23-amd64",
-    "container_hash": "709f1f42a6bfdfcb80a8113822b0484ed036d09aa7c6521b35f81a85ee4b6b85",
-    "git_hash": "33a0cf9c581bcf5625e2d906a10117288c2d503b"
   },
   {
     "date": "2023-02-28",
@@ -1730,30 +1291,6 @@
     "git_hash": "2fd175cfa1a0637b6a1056ccbbe43c7c2f1cb513"
   },
   {
-    "date": "2023-03-17",
-    "version": "1.2.7-rc.24-amd64",
-    "container_hash": "d3e7774360f6e45de5c4eab95e5e6e7a6333798d1bd6e891c0f6048bcf39beb3",
-    "git_hash": "9f6a79a7260e0f76392dae6e0e885e59094ad76f"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "1.2.7-rc.24-arm64",
-    "container_hash": "2ed00d5d1595c63be8db55eba7bbc6b804b36fdc52079458b38c18abd7ef6214",
-    "git_hash": "9f6a79a7260e0f76392dae6e0e885e59094ad76f"
-  },
-  {
-    "date": "2023-03-21",
-    "version": "1.2.7-rc.25-amd64",
-    "container_hash": "b4ea643a438b757bd06656ffdcdf7c6ca09fbeeb1a00d9ccebb582e1c4f64095",
-    "git_hash": "37f046845ec20d9b6344dae1d9fb5af423192a17"
-  },
-  {
-    "date": "2023-03-21",
-    "version": "1.2.7-rc.25-arm64",
-    "container_hash": "6ec4aadf36591d0f6f4fa42e74216309d63bfdb2176f6b42d6ecfd3818028ed7",
-    "git_hash": "37f046845ec20d9b6344dae1d9fb5af423192a17"
-  },
-  {
     "date": "2023-03-21",
     "version": "1.2.6-amd64",
     "container_hash": "270142d7c0d016a18c199f4580994733ed23851132a0fec5d164ed0abc7c907c",
@@ -1766,18 +1303,6 @@
     "git_hash": "2fd175cfa1a0637b6a1056ccbbe43c7c2f1cb513"
   },
   {
-    "date": "2023-03-27",
-    "version": "1.2.7-rc.26-amd64",
-    "container_hash": "6a738d9f9bc424f818ba51eab847ef76971d854210b26f010cfa13488d6360e1",
-    "git_hash": "2ba23c7247e5a380bbd5c0ef30b4842f296c6c0d"
-  },
-  {
-    "date": "2023-03-27",
-    "version": "1.2.7-rc.26-arm64",
-    "container_hash": "7ce0dd8bfd532d72689b049edba5d1f8d3743c9785aea4ba15887b846f3fb0fe",
-    "git_hash": "2ba23c7247e5a380bbd5c0ef30b4842f296c6c0d"
-  },
-  {
     "date": "2023-03-28",
     "version": "1.2.6-arm64",
     "container_hash": "7896793a3b3b9677c5b0fa15e009ff88fa56950dc314f17dd97a7683eeffc210",
@@ -1788,18 +1313,6 @@
     "version": "1.2.6-amd64",
     "container_hash": "45b5562e314be957c6e011aea9fb903081b64f458469b857016fc981090958fc",
     "git_hash": "2fd175cfa1a0637b6a1056ccbbe43c7c2f1cb513"
-  },
-  {
-    "date": "2023-04-03",
-    "version": "1.2.7-rc.27-amd64",
-    "container_hash": "51c5dc02705b561b7fb8b5b2073aa8798392203eddc853510f519b996c1d96eb",
-    "git_hash": "2ee04ba45c283a80fac7ed4bededa58b32d072ed"
-  },
-  {
-    "date": "2023-04-03",
-    "version": "1.2.7-rc.27-arm64",
-    "container_hash": "eeb4a126374d0a45859038d3db666b456a0591c235e50a01c2e29f51ea8d92f9",
-    "git_hash": "2ee04ba45c283a80fac7ed4bededa58b32d072ed"
   },
   {
     "date": "2023-04-04",
@@ -1851,18 +1364,6 @@
   },
   {
     "date": "2023-05-03",
-    "version": "1.3.0-rc.0-amd64",
-    "container_hash": "8d578d3af12a5b9e999c68e36079f8e3a10cc10a221dee06a6d2ea4d9f2464cf",
-    "git_hash": "bf14c2b8b35f79554b83b5fb3ce3b1c70feb5c42"
-  },
-  {
-    "date": "2023-05-03",
-    "version": "1.3.0-rc.0-arm64",
-    "container_hash": "9e23cd99c86f69096d7f5ab2dcb832864e87371e5a018a00b1d33462b4d24576",
-    "git_hash": "bf14c2b8b35f79554b83b5fb3ce3b1c70feb5c42"
-  },
-  {
-    "date": "2023-05-03",
     "version": "1.3.0-amd64",
     "container_hash": "63e07e7ed6cf4741891d355a50561753553b4361f7eae2e263477b119ab2c35d",
     "git_hash": "c3faa22c024deef6e99b082f4f8a433effc9adfc"
@@ -1872,41 +1373,5 @@
     "version": "1.3.0-arm64",
     "container_hash": "202ebaa42dac1afd0e989457a09673f9c8189114fb2d9a61b3e82bf48febdc7a",
     "git_hash": "c3faa22c024deef6e99b082f4f8a433effc9adfc"
-  },
-  {
-    "date": "2023-06-08",
-    "version": "1.3.1-rc.0-amd64",
-    "container_hash": "2769fcb3fa3628b12006554a12ffc7b810f727f4a6184d052709ed03b8a1fa11",
-    "git_hash": "6ebb716a50913106cf7c1c8f29d9ce2e08ca00f5"
-  },
-  {
-    "date": "2023-06-08",
-    "version": "1.3.1-rc.0-arm64",
-    "container_hash": "b5b31e4fef8686d42382fec5db1fac71eb41a63ddbe523f96a76ebb72a0179d3",
-    "git_hash": "6ebb716a50913106cf7c1c8f29d9ce2e08ca00f5"
-  },
-  {
-    "date": "2023-08-17",
-    "version": "1.3.1-rc.1-amd64",
-    "container_hash": "3f698afaa449e9b314f514cd177bbcde26e39c8abfb43d53b2532768d7d1ba1a",
-    "git_hash": "5f34cc3f34d7a9eadfd35f2761119a8be056c4e0"
-  },
-  {
-    "date": "2023-08-17",
-    "version": "1.3.1-rc.1-arm64",
-    "container_hash": "95ba67ba814b80f3f00ec643461719a17989996de4db556c8ef141fda1a44fa4",
-    "git_hash": "5f34cc3f34d7a9eadfd35f2761119a8be056c4e0"
-  },
-  {
-    "date": "2023-08-18",
-    "version": "1.3.1-rc.2-amd64",
-    "container_hash": "9bf5fc1540c36201b80158028558d80de3bc5e39a5ca6576e99bf3a4b781834a",
-    "git_hash": "855679dcc6e9005c49bbfcb9b995d8cbc6fc8a2b"
-  },
-  {
-    "date": "2023-08-18",
-    "version": "1.3.1-rc.2-arm64",
-    "container_hash": "ea2026520a7da72e408e9fa87a057c4c6425d57bd397c0f962f1df65449691de",
-    "git_hash": "855679dcc6e9005c49bbfcb9b995d8cbc6fc8a2b"
   }
 ]

--- a/tenant-security-logdriver.json
+++ b/tenant-security-logdriver.json
@@ -10,21 +10,6 @@
     "git_hash": "9ecb1606b036fb3f8fe94f154a2d54e03cd38c6b"
   },
   {
-    "version": "2.2.0-1",
-    "container_hash": "63d60dd2b5d9e26309c80504f8fe39bff1feaa2aa42c9d3efade73ada90f2b8d",
-    "git_hash": "ccffddb87935c3c05014da102b2572535ed5d538"
-  },
-  {
-    "version": "2.2.0-1",
-    "container_hash": "ee555c0a5c4acbc96949d21f70e9793e1e1bb44d557c283f01b734ed185f72ec",
-    "git_hash": "ccffddb87935c3c05014da102b2572535ed5d538"
-  },
-  {
-    "version": "2.2.0-1",
-    "container_hash": "eeabc1814f92937ee93b22e6c9b58f6a52bb21c72a15df151c989db884488fe2",
-    "git_hash": "ccffddb87935c3c05014da102b2572535ed5d538"
-  },
-  {
     "version": "2.3.0",
     "container_hash": "d04347bec6c13a448d6e073fb96cee3ce48d59e720577cde9ef5988efc697551",
     "git_hash": "15375a1c7ce094899d2bf024e489929bdc65234e"
@@ -33,21 +18,6 @@
     "version": "2.3.0",
     "container_hash": "d35e88f806c17cad4d6d07ecf403009284a6d3094d28224e5a3ed3e4265e8616",
     "git_hash": "c98af67566bd069f0c437c7674e98d5ddf52bd32"
-  },
-  {
-    "version": "2.3.0-1",
-    "container_hash": "14230e4d5e55fbacc9c64f4b9cbb3ba0192cdb2993b8522e4d8033c4c42374c9",
-    "git_hash": "cbe8b85a0e1bef73fab310e36ce179b9162228d6"
-  },
-  {
-    "version": "2.3.0-1",
-    "container_hash": "6fc47322e5ea5d968126aabb190787abd2ecd000e6f37d3e541a0ded181fd298",
-    "git_hash": "cbe8b85a0e1bef73fab310e36ce179b9162228d6"
-  },
-  {
-    "version": "2.3.0-1",
-    "container_hash": "ba2bb1f00fc170358a37894e63b792b65ed66b69466964d63861a6e49fc01764",
-    "git_hash": "cbe8b85a0e1bef73fab310e36ce179b9162228d6"
   },
   {
     "version": "3.0.0",
@@ -88,21 +58,6 @@
     "version": "3.0.0",
     "container_hash": "fb6d48397eeb29afdf6145691215395fe121d09b7f76dec367d39c211e5d79b7",
     "git_hash": "886cd1c34eb2577a306c621af3f2d5f1ef76ffe1"
-  },
-  {
-    "version": "3.0.0-1",
-    "container_hash": "2639e11f8dc18442ddf63daaff2bca251999c036b786ccb4d6172afff0683553",
-    "git_hash": "63b8c4b3fa6b9afafc6cc0084a256b7272ee614e"
-  },
-  {
-    "version": "3.0.0-1",
-    "container_hash": "73d07380b5b9087f01749c4aa865f957e8104481fcdf5abbd928c97f9649dfd5",
-    "git_hash": "63b8c4b3fa6b9afafc6cc0084a256b7272ee614e"
-  },
-  {
-    "version": "3.0.0-1",
-    "container_hash": "cd21cd4db856306c8d7c239d4dbf235d4f885f431d28d4cafdfd7551a6060c7a",
-    "git_hash": "63b8c4b3fa6b9afafc6cc0084a256b7272ee614e"
   },
   {
     "version": "3.1.0",
@@ -360,121 +315,6 @@
     "git_hash": "bc732f82b91b40381bd3e65545ba5a33357478ef"
   },
   {
-    "version": "3.3.2-pre.18",
-    "container_hash": "d0b5ca8e965fadfe3dc34c743d912bd4fcdc52f35061c3d4f13d2697c8b50dac",
-    "git_hash": "4bc4360abedbbdda124cd7467e966cbcc3f1c1a2"
-  },
-  {
-    "version": "3.3.2-pre.20",
-    "container_hash": "1020e334e739e133b46b6d7e40409dbbe62a089764acfee81d608317cec4329d",
-    "git_hash": "346368df5b4d96c7f36ae36343a43566df0e935d"
-  },
-  {
-    "version": "3.3.2-pre.22",
-    "container_hash": "b9ee7b27b49e44eb06228ecd26f9cee9e6dad4e6312c51119f9a4b0b3f95eb90",
-    "git_hash": "0999fcf1cee8630c5a4b7de12b5304135f9a8a60"
-  },
-  {
-    "version": "3.3.2-pre.24",
-    "container_hash": "7fb988bfd043686dca5be0357caf42fcc11bf14e99cd97084506c249e17ce88f",
-    "git_hash": "ff85d3ebb6db02883c65a4dde4c2daa51f0999b6"
-  },
-  {
-    "version": "3.3.2-pre.26",
-    "container_hash": "525623e1c0e01ad79b012d1572017ea776733d50cda4f8add4842a41a39191cf",
-    "git_hash": "d6197818bb3f13f07d01d44aee1865688c5af6cc"
-  },
-  {
-    "version": "3.3.2-pre.27",
-    "container_hash": "3e7a6adbdc82f8642e6c3f396db1125d7d0ca5b8edf9324bf6ea9fc71650f43a",
-    "git_hash": "29a8d66fcb8fab2c5a274ca40698447fc71b1d75"
-  },
-  {
-    "version": "3.3.2-pre.28",
-    "container_hash": "cc665ac703665df142003946cafaa2762d79fca5fad32e4e5a12e58fe77dc991",
-    "git_hash": "0ef17e5b6c0ae4f57a2c58040179780f1ec75c71"
-  },
-  {
-    "version": "3.3.2-pre.29",
-    "container_hash": "a626e1c74a02e62d93b753af8375f382690dbffb19df306befe9f843519d3cda",
-    "git_hash": "39c586c19c4d01ed8077685d53a13a53fd3d41de"
-  },
-  {
-    "version": "3.3.2-pre.3",
-    "container_hash": "328601e37d7d7ee7cc061cd41efd188322b951ab7f56217e4193a4e0ede4324e",
-    "git_hash": "72d0723b2ad55674df7d4172ee69da20fc22d1e5"
-  },
-  {
-    "version": "3.3.2-pre.30",
-    "container_hash": "1d75d8da7842a48080e508084195dd1ccac62f37531789da45d319a63a5379a5",
-    "git_hash": "841de654817bbb8e85eda4abb03419329f4dbd4d"
-  },
-  {
-    "version": "3.3.2-pre.30",
-    "container_hash": "ddd6f2d3d38ba2783a6349e2bf9aeb3e15fb0976a8796dc7c49a6fa416bf8c71",
-    "git_hash": "841de654817bbb8e85eda4abb03419329f4dbd4d"
-  },
-  {
-    "version": "3.3.2-pre.31",
-    "container_hash": "de9c4a628007e152eaa44d178df5ef04d7ed6effcc997ad9897ea63118720066",
-    "git_hash": "15090355b55db0894c7f26412e19560cba1afeab"
-  },
-  {
-    "version": "3.3.2-pre.31",
-    "container_hash": "efb44cabf9f15c8873daf9fe40c67795ad75f32ea102186b6bd220bc46e70347",
-    "git_hash": "15090355b55db0894c7f26412e19560cba1afeab"
-  },
-  {
-    "version": "3.3.2-pre.32",
-    "container_hash": "9bf511f554db4b374b91272e99c7a80a7b437b3bc6f0ff5b65b7e2e98285ccc6",
-    "git_hash": "5a1e5c29fb30b66eb3f8a55cf9fc4de2846473b9"
-  },
-  {
-    "version": "3.3.2-pre.32",
-    "container_hash": "dcd20f73f99ecb1511bc50732cd98b74b8635f5dc46f96667ea29a96d8db1cde",
-    "git_hash": "5a1e5c29fb30b66eb3f8a55cf9fc4de2846473b9"
-  },
-  {
-    "version": "3.3.2-pre.33",
-    "container_hash": "056e690deef219a9b3606ec75a9d6d3261f6928aa0a4aad0d11ccf2cc4a06324",
-    "git_hash": "bf8ee5932481212d9971b719dd5ef1d5cfa10416"
-  },
-  {
-    "version": "3.3.2-pre.33",
-    "container_hash": "1963dd54b29e0f1a93ba262979ba7f0e5bdb36c1dbee22cee679e1d71ec84d52",
-    "git_hash": "bf8ee5932481212d9971b719dd5ef1d5cfa10416"
-  },
-  {
-    "version": "3.3.2-pre.34",
-    "container_hash": "616665609146c84a3f90995e6b5ad3caae384c2bb2e4555c6e6727e447d46690",
-    "git_hash": "90aa74f862b924eb9d2c3b4a3e4bb53d36f309bf"
-  },
-  {
-    "version": "3.3.2-pre.34",
-    "container_hash": "a99cb461e30b1d03903f89c4e7a76e494393ec10ce8d4a7c56cd56619b95d652",
-    "git_hash": "90aa74f862b924eb9d2c3b4a3e4bb53d36f309bf"
-  },
-  {
-    "version": "3.3.2-pre.35",
-    "container_hash": "6e76d88a24ed9813781d9685ad033f2f714eef352d1f76e97cb8a6c81425ff28",
-    "git_hash": "8d178f98e350ffe9eaccae202def42491fccccee"
-  },
-  {
-    "version": "3.3.2-pre.35",
-    "container_hash": "73f5a64472052ef24bc33049d57e3e726b1ffc3119513a1d0ecb51c24a9b30e0",
-    "git_hash": "8d178f98e350ffe9eaccae202def42491fccccee"
-  },
-  {
-    "version": "3.3.2-pre.36",
-    "container_hash": "2a166d9a2cef5d1e5b989d03a84ca044ef6847a6f1f398578d52ee12d812dfa7",
-    "git_hash": "d7a495d7bcf089481ed589ddc1e539fe4e8c872e"
-  },
-  {
-    "version": "3.3.2-pre.37",
-    "container_hash": "05eab0c82ae8c39c6cd8d16669d14c1ad0bf91d0d69a4720158967db414c0c10",
-    "git_hash": "cc27a17e33bae70e996dc0fa219cc0a4d7fc35a0"
-  },
-  {
     "version": "3.3.3",
     "container_hash": "1a14a7ec5af58198136c52068d503fa4e43e52432804cb0e30535d6f73cdabaa",
     "git_hash": "5d028ca257582fc1c6dd926aaa0c521cdfc369c5"
@@ -515,11 +355,6 @@
     "git_hash": "5d028ca257582fc1c6dd926aaa0c521cdfc369c5"
   },
   {
-    "version": "3.3.3-pre.2",
-    "container_hash": "7157c86c63ec4043db6b690f85f482805da686c43e1e69d2f1916434c763919a",
-    "git_hash": "ac1b1eb173e583fe706d7be6f30b64d1e407fb29"
-  },
-  {
     "version": "3.3.4",
     "container_hash": "26040a1801f3aa8b45c9c3e6483c8c19f6c7468c671b5a1b9367b8523fb5b43c",
     "git_hash": "a603935e33b10aa1e5694b691c03fabba1c41618"
@@ -558,11 +393,6 @@
     "version": "3.3.4",
     "container_hash": "f631e0ac8e9aca0ea241747d45a2a44b68311ab1b45ac8266ec8eced40d202fa",
     "git_hash": "a603935e33b10aa1e5694b691c03fabba1c41618"
-  },
-  {
-    "version": "3.3.4-pre.2",
-    "container_hash": "cb9704fd85ff0bf6400b6477478560150212392686805791be0d144fe0f8443b",
-    "git_hash": "7b6f49ac3c9ab8461a703c32f5fd2ea3624fe915"
   },
   {
     "version": "3.3.5",
@@ -610,16 +440,6 @@
     "git_hash": "6a283bdc337d3c1d1c72dc3670f50f3b7eca378f"
   },
   {
-    "version": "3.3.5-pre.2",
-    "container_hash": "56012ff916d038684d43ef789acdb7f05c088371feca31bdb3a19c199ba5ea88",
-    "git_hash": "2cfd167ec61fa51a2003d316bc8bd45ec93231da"
-  },
-  {
-    "version": "3.3.5-pre.3",
-    "container_hash": "6ec1db35c6ec53f41594d9e3044dfb642e278e69999f212552026baa542ff0f0",
-    "git_hash": "637ea19222730728f17554efad8bb53a22081d09"
-  },
-  {
     "version": "3.3.6",
     "container_hash": "04031e9875fd4e1bcfac162121a79df4b908d474bb9adf28812c9884691e2b9f",
     "git_hash": "e9220eca51cc9e0307fea973a304a7a1b625b7a0"
@@ -660,101 +480,6 @@
     "git_hash": "e9220eca51cc9e0307fea973a304a7a1b625b7a0"
   },
   {
-    "version": "3.3.6-pre.10",
-    "container_hash": "2984a306be5530d9bc8a005d2b3366e0b81b170ef9c2662adc4b8a46f7b1ca6a",
-    "git_hash": "c79bb76197fa0ab507a606732157713983ae3250"
-  },
-  {
-    "version": "3.3.6-pre.10",
-    "container_hash": "98f6cdc49596b2e1fe9b763de0eb96f1a8e19d4a7bbc6b4c5d784f37ae9b2439",
-    "git_hash": "c79bb76197fa0ab507a606732157713983ae3250"
-  },
-  {
-    "version": "3.3.6-pre.2",
-    "container_hash": "2ceca3b98619443b36c8de448bdfc55fa91dc688c646add58bf60b10e51e217d",
-    "git_hash": "585ee70f6f83b5d8e5721c7b00a3e03cd97389c6"
-  },
-  {
-    "version": "3.3.6-pre.3",
-    "container_hash": "814bb480d1bc12f935b6c240625eb9241a1e134bb8a690829f6f974c3af04f5b",
-    "git_hash": "6f24845ab89a995923b4e452c859384ad3381821"
-  },
-  {
-    "version": "3.3.6-pre.3",
-    "container_hash": "f4331b2b5a37f2a390608a0b1caee1d60ae802216cd4388f687e54e62963c123",
-    "git_hash": "6f24845ab89a995923b4e452c859384ad3381821"
-  },
-  {
-    "version": "3.3.6-pre.4",
-    "container_hash": "03ec6aa265d24caedcce2b51a83bc632a172537dbf20a368303f7e767182f466",
-    "git_hash": "12d88b6a99dfaecfae071774e82c8f781e0c404e"
-  },
-  {
-    "version": "3.3.6-pre.5",
-    "container_hash": "11e78ece0c18506adfbfccd535bc1c142c0abcf1205c03f12d56d33848ea770e",
-    "git_hash": "9b893b452a43dd98810b0264bef030dad945deaa"
-  },
-  {
-    "version": "3.3.6-pre.5",
-    "container_hash": "2f494666c263d1fafbf971511bf9af94be0451ac8c8009ba4b72fb85ce2614ee",
-    "git_hash": "9b893b452a43dd98810b0264bef030dad945deaa"
-  },
-  {
-    "version": "3.3.6-pre.6",
-    "container_hash": "22093c902adf6dc131cdfcc096f7a417eb0363f4526a9af361250ebfc288e810",
-    "git_hash": "77983400de89e84acf4dbba31339ed35cf5a5b0a"
-  },
-  {
-    "version": "3.3.6-pre.6",
-    "container_hash": "b22fae30f062f02bdcb59d88099a6227b9d7f36992fca074e7339f2c3c4e4225",
-    "git_hash": "77983400de89e84acf4dbba31339ed35cf5a5b0a"
-  },
-  {
-    "version": "3.3.6-pre.7",
-    "container_hash": "116106af5f673913310c277ff8335912850d6cfcc78d1734c5d3491fb06a1053",
-    "git_hash": "80960241bfb24b7a550e6485f5f85b0cc6c7d99d"
-  },
-  {
-    "version": "3.3.6-pre.8",
-    "container_hash": "89eae1ebc0f6992f98f1997fb88dca1e28752b6633226a54fc683c3777c41c6f",
-    "git_hash": "d0fed2c1e3a6c3993f061eb6bf4462819c599071"
-  },
-  {
-    "version": "3.3.6-pre.8",
-    "container_hash": "ba2731c95866b3da3724abda6bf25f6e4c102be8df3a46f0ee266255bbd9869f",
-    "git_hash": "d0fed2c1e3a6c3993f061eb6bf4462819c599071"
-  },
-  {
-    "version": "3.3.6-pre.8",
-    "container_hash": "f16954c0ef86807232f51648e7c0d3670bba87c41f1796fbee1473c8b4657b10",
-    "git_hash": "d0fed2c1e3a6c3993f061eb6bf4462819c599071"
-  },
-  {
-    "version": "3.3.6-pre.9",
-    "container_hash": "b518d61e9bce2994036fad06dce162407aedc60d63355fb308f2d05b18a8510c",
-    "git_hash": "29609b32accbf75805ca957870e7fffd920e8f41"
-  },
-  {
-    "version": "3.3.7-pre.2",
-    "container_hash": "3cfec760e4112f93b64440abd4e0b1c4d3fb21a1129e6d45b713ad5d0be28bd5",
-    "git_hash": "b683d4d7eeb38d7e77ab8cd89bebae70e9bc6916"
-  },
-  {
-    "version": "3.3.7-pre.2",
-    "container_hash": "70f68d0e672e537519a6fd71f53b13c89d3b0787d31117ca231b0b0ca8068809",
-    "git_hash": "b683d4d7eeb38d7e77ab8cd89bebae70e9bc6916"
-  },
-  {
-    "version": "3.3.7-pre.3",
-    "container_hash": "0474fc80bd1a47b3cf866217abc16161dfb5d0a91450101bca7065df67d9a4f5",
-    "git_hash": "101755150e2e0c5d950858cb540cb1164c384a68"
-  },
-  {
-    "version": "3.3.7-pre.3",
-    "container_hash": "67c8cc8e0a9b64d1741ad7cca325e8b74a7224225aa231f39fb82b2596e54689",
-    "git_hash": "101755150e2e0c5d950858cb540cb1164c384a68"
-  },
-  {
     "date": "2021-10-01",
     "version": "4.0.0",
     "container_hash": "35c558b32f6005e3a1797a991c87afa19115d69490bc56c4a9cb92fd048f9e86",
@@ -766,456 +491,10 @@
     "git_hash": "7be22533c23b7902d0fbbfad1dc0f935ae7cc6a3"
   },
   {
-    "version": "4.0.0-pre.1",
-    "container_hash": "4aebd6ef1a594039bc1f31b710776df3a4b3a6e300abd1fc97c549b075061e4b",
-    "git_hash": "e3995891a2bdc18b43163d3f5222cc399ea2eae3"
-  },
-  {
-    "version": "4.0.0-pre.10",
-    "container_hash": "466f0e97db432f57f4d86214cb27f155633a71a339ccda81cf778569fcb93f7d",
-    "git_hash": "3471fdc11ad4676e28f08dd88a37b84663952062"
-  },
-  {
-    "version": "4.0.0-pre.11",
-    "container_hash": "17becb4f75312a2d22405eaeb676494309097be91e5fe5ecd265762160791efe",
-    "git_hash": "ffa102c96f4a386271ee9ddb89fe2f014004efcb"
-  },
-  {
-    "version": "4.0.0-pre.12",
-    "container_hash": "27db71531b78848b622554a727df6fb3136d4b7ad102336a3746e835ba7573b9",
-    "git_hash": "c3f19e412feb0bfc39115a0c1391564b962c53a9"
-  },
-  {
-    "version": "4.0.0-pre.13",
-    "container_hash": "87fed9f890892b1fc8d41877467aacc14cfd94e75a7e93d53f2357445c225a93",
-    "git_hash": "b78ae7bd084c5c752ffa9dc6e9e19026242aa594"
-  },
-  {
-    "version": "4.0.0-pre.14",
-    "container_hash": "b146eb215f79ca47259dc3f4f3c13a320b2313ab97051f26f7291d6ad806797b",
-    "git_hash": "852148a9272af154a13eb20974748fcf23334bdf"
-  },
-  {
-    "version": "4.0.0-pre.15",
-    "container_hash": "deb0bc448d29693180a99fd6ea6b795ea1d938bbc6e8cbf3ef14303be5b34677",
-    "git_hash": "d4caf066d503c2cc7d226c33ae8379b06c04f12f"
-  },
-  {
-    "version": "4.0.0-pre.16",
-    "container_hash": "52b1061eb0e06a883d9593ed64d1df8982f6a0f110d4ee627d3f6b37434e4c31",
-    "git_hash": "689a63ee441f16456bdc1fce0c1cd5f1d95fe403"
-  },
-  {
-    "version": "4.0.0-pre.2",
-    "container_hash": "a9eacaba3331e8aba32b0f6099573175e8c28346071d4a07a0e14d3672d43043",
-    "git_hash": "0e1cd943fa575119c44a94d05911221da38a7db5"
-  },
-  {
-    "version": "4.0.0-pre.3",
-    "container_hash": "7d13a8466ac58d9de4a714fe63642188a33b7499319eb59948925b3488999ac2",
-    "git_hash": "79aa24b7de39db265ce98da2aa0cd8f680ecba3a"
-  },
-  {
-    "version": "4.0.0-pre.4",
-    "container_hash": "2f2073cbf525dcaaa9b722385c136d815a83347d27a30ae3d9fc0f56cb112e93",
-    "git_hash": "d0e3c279cf0c2938a51ffb2ae241b6ce01a4b63f"
-  },
-  {
-    "version": "4.0.0-pre.5",
-    "container_hash": "388f55c9d9d805f5d98c462960dd1c0b8a8bc9ef5caf05dc6907a335434e98a1",
-    "git_hash": "32178209000cb076dc9c9af22d2445092e15321b"
-  },
-  {
-    "version": "4.0.0-pre.6",
-    "container_hash": "95c7bf50ab1831639f3ca0e0a67188bdf72fd84f930cd21acae0f1e3e6f4c6bc",
-    "git_hash": "f93195947e9f8312dc5136cf36f4feafdab7749f"
-  },
-  {
-    "version": "4.0.0-pre.7",
-    "container_hash": "a6dec67d903304195b6f726fa0fb6200eb6f7a78b5ead019ea6cd464276105fa",
-    "git_hash": "cf6c49c7f8d1c8ea451a70f13324c80f420bcb5b"
-  },
-  {
-    "version": "4.0.0-pre.8",
-    "container_hash": "a6d34bcf8859d3eeb016625e0e7be3e4334dca1e9aa04413b251aeff07ae6a8f",
-    "git_hash": "073b10a293cd4eec599414d62effcddb773108a1"
-  },
-  {
-    "version": "4.0.0-pre.9",
-    "container_hash": "9f6630e52d74fd30ad0485e177cf0833b09181b721e21451a0606d5a12e1a355",
-    "git_hash": "f6cfea9884631fc082667302310546a434ae0fbb"
-  },
-  {
-    "version": "4.0.1-pre.10",
-    "container_hash": "eb3abafebd147d25ff10e65eadfafab9bc7975eccef4187469ce31064fbdac02",
-    "git_hash": "9f299607bd7b337c73c735c778af3979d1b87e10"
-  },
-  {
-    "version": "4.0.1-pre.11",
-    "container_hash": "4d5cd5cf55217b8bf7b9ef2f9c0560204cdb72e036971cbe1f069e8ad94892a8",
-    "git_hash": "2b067954df5f656fa03ec20c9e61ee8116fec69a"
-  },
-  {
-    "version": "4.0.1-pre.12",
-    "container_hash": "a4c331a651edc2db3280038fcfc301546eb7e045d14b97d0f0ea11f6a9363e0c",
-    "git_hash": "98e57c89f9cd70c4f09b693418207e3f0d51185a"
-  },
-  {
-    "version": "4.0.1-pre.13",
-    "container_hash": "1381fa64e23a73f8d28517b04b9f59b27e2795162e60fa05f12a842495c2da9d",
-    "git_hash": "99f835e3a936d18268ebdb904440907282565214"
-  },
-  {
-    "version": "4.0.1-pre.14",
-    "container_hash": "b93c631fa7e143a7e46828deddd66ec84d44b92c77316f1d5dfc1e7834fea176",
-    "git_hash": "9f4493465fbf8a6fcd277718d5797105947180da"
-  },
-  {
-    "version": "4.0.1-pre.15",
-    "container_hash": "6d476bd40dff918e40766defe58053f0f9dda8f1b88e307141ec071a1f6981b2",
-    "git_hash": "3144731c9063d5ec4b67cdde15468ede257ec9e1"
-  },
-  {
-    "version": "4.0.1-pre.16",
-    "container_hash": "65ebb478c0ef7d5aa97137d79253f0ad9cd503a2a5aaf4ca7e003f271efb8eaf",
-    "git_hash": "b01e76358e3dfca2c77ffefedaeee6f0dc2c974a"
-  },
-  {
-    "version": "4.0.1-pre.17",
-    "container_hash": "31ab7035aa50953aa82d4196e470b03ffac6cc3b8928fa085c209f360385ddf0",
-    "git_hash": "2e8132399b1f0c02fe73f9a10c5999bcbe2bd3db"
-  },
-  {
-    "version": "4.0.1-pre.18",
-    "container_hash": "ce9052ce09d91f23dc564513ede763586bef30661b7033507f4045222ae8f031",
-    "git_hash": "0f8a67bd4183dfdc8f19d3b339dfbda39709191e"
-  },
-  {
-    "version": "4.0.1-pre.19",
-    "container_hash": "86115475c11ee6ebf87d4c7be84ef22a4dd8cfdecf5c8f3453bd3a37ce25e367",
-    "git_hash": "bdbb6571d71cb908177e6bd6ecf7f8f2680a66a2"
-  },
-  {
-    "version": "4.0.1-pre.2",
-    "container_hash": "b2ddf2d7de1b32db40209f3389244c9a37d43720165188171a0e3a3eec259e78",
-    "git_hash": "6bda3e8006e0e34799566facc2f5ebb6be8fd246"
-  },
-  {
-    "version": "4.0.1-pre.20",
-    "container_hash": "661d1944468641bd40c7792915a49a81dc47efbdcd6e1d0bd68dcbcbebaac600",
-    "git_hash": "516f70cbbc5087e56da66513ad47274f82fd37aa"
-  },
-  {
-    "version": "4.0.1-pre.21",
-    "container_hash": "4887d742d18fa4a3bbf3aad9dac6877861ea0f6c93b790b3afee9b3ac45892bd",
-    "git_hash": "bdaae1b4ecf41fdc17133cf94f4598b24f7aba86"
-  },
-  {
-    "version": "4.0.1-pre.22",
-    "container_hash": "14473fdc69eda62f4d230c93add4bdab791f941aa6038289de4264b0e8c76660",
-    "git_hash": "5f569ae05b841798618ee4e574e13f498b991987"
-  },
-  {
-    "version": "4.0.1-pre.23",
-    "container_hash": "bf904375dde583d82b1388e1b16657565200b0ee7a7068fdb00432363c358699",
-    "git_hash": "24a0d5a214c318869f74a0af30135a2645b60954"
-  },
-  {
-    "version": "4.0.1-pre.24",
-    "container_hash": "f0d877c7d546b5f9d632f89467bcc9d35361c58c38c3e1bcec3dddfa5ccec632",
-    "git_hash": "40d8348a4de9a3003cebf57d5f6db336d0e22c1b"
-  },
-  {
-    "version": "4.0.1-pre.25",
-    "container_hash": "baa93279565c70f3626fcc6f88926c2a0c7f5fa83a4f923c540e8e3cd1dccedb",
-    "git_hash": "b47a163dd85a60d0ec3c3ebef59f0bda13dd73ec"
-  },
-  {
-    "version": "4.0.1-pre.26",
-    "container_hash": "c2632e6749b7fe4ad4ea5995273291fc5cdbe66286b5bd87f282670570de8eaa",
-    "git_hash": "fa98f306a96a2f6c5dd76ab7347dcf529819eaaa"
-  },
-  {
-    "version": "4.0.1-pre.27",
-    "container_hash": "38efba21e7665853fd28d64eb334fcd04e88cab1cae4f14679a07ecb822d6424",
-    "git_hash": "b36d800cfb401d36327e588726f54bd381ea878b"
-  },
-  {
-    "version": "4.0.1-pre.28",
-    "container_hash": "426b9470012e7dc40e61b696a8a6aadd816ab894b90083a98955409883c8e3b2",
-    "git_hash": "147e164ef22140172e1bc103003d5fa3c7a777d5"
-  },
-  {
-    "version": "4.0.1-pre.29",
-    "container_hash": "34e18840dca7e464bb6e2bca41aa5073ffde7dfe7b08f662820a874174e6e3da",
-    "git_hash": "e210fc2f0a0c99672188732c6ed0976155acf081"
-  },
-  {
-    "version": "4.0.1-pre.3",
-    "container_hash": "aa6611978c40d878253279407b9d4be106bd10f0ba8168bea2f255f1c71e81e8",
-    "git_hash": "67b63265ba78c438eac0dd1e8a1c8fcc3be80cff"
-  },
-  {
-    "version": "4.0.1-pre.30",
-    "container_hash": "3581669c1d374dfa8edcb3ae6b4b465ca462babbdfe4e0fb408038f2f020f653",
-    "git_hash": "eb438ec3183fc71bdc2c67fa723f101634df95ae"
-  },
-  {
-    "version": "4.0.1-pre.31",
-    "container_hash": "cd4129e66798783a25651b008ecb28870e4b6d22f6ec3451765aba0a6e37725c",
-    "git_hash": "f794fa2c04ddd0a72e4a80ca98e9a6d8dfe95612"
-  },
-  {
-    "version": "4.0.1-pre.32",
-    "container_hash": "ae5f800fb366f0cf895246c429f953bcff4419e819d5260b297538ceb0c0440e",
-    "git_hash": "12b5582c8ac0226e891d9ccac97d004164046f9a"
-  },
-  {
-    "version": "4.0.1-pre.33",
-    "container_hash": "f96fa13be7f81be755beae5966c3c9fb096568c5aa76b3c398ab427eee22dc69",
-    "git_hash": "9a46092a946acfd186d596cb3af1646eea35d84d"
-  },
-  {
-    "version": "4.0.1-pre.34",
-    "container_hash": "7e66bba699d96ee9eff44b7acb3eaf4e52b267039ced0f2585effc3b1babffa5",
-    "git_hash": "de7761585381d865ee10c6f58547b59c5f27b7be"
-  },
-  {
-    "version": "4.0.1-pre.35",
-    "container_hash": "27bb2ea868ccb87bfa460fa0b0a6a7473ba8a58fcc5e6155c504e8de935b6a90",
-    "git_hash": "9a9921ab226cc84a47c2ae82e8b4e8ec7f89959f"
-  },
-  {
-    "version": "4.0.1-pre.36",
-    "container_hash": "c919b8a1083cf8cac46b97dfb7b3999c9f009af68fe1fbc8f1903ee7d0740aba",
-    "git_hash": "cc9c71501a137aa9a362b809255694ff36a4298d"
-  },
-  {
-    "version": "4.0.1-pre.37",
-    "container_hash": "b601ac94187d448d39d5ad06ef04e60c6889635056e2348fb30c79b65131efa4",
-    "git_hash": "aaa17fcb6ac03d2912fda057a0c2e79557f6674e"
-  },
-  {
-    "version": "4.0.1-pre.38",
-    "container_hash": "38dd545ba6f658bc5069b5a7e872f9add1199a8ebde86ba461baf764255c976a",
-    "git_hash": "8c9b168d9775b7bcc6ff3a0335bfb5c17e19219c"
-  },
-  {
-    "version": "4.0.1-pre.39",
-    "container_hash": "05cfa79f4894f714a8cf8f641b0d5872aaace2df066bff4babcf094da4325573",
-    "git_hash": "63fc56cf2c53fd627f44788f0b2b12f499496213"
-  },
-  {
-    "version": "4.0.1-pre.4",
-    "container_hash": "56dd7ae1629f143ea1ee5a5dc33c74a84e26134c25781ed8f6b7bfef3371ba0e",
-    "git_hash": "524190f4dfe93d7ebd1994b467c71d3fdfcfc790"
-  },
-  {
-    "version": "4.0.1-pre.40",
-    "container_hash": "0650a92a04bbbb79aa78069c23d4f0340cff38da60b902b5179e4ddb771dc29c",
-    "git_hash": "2bd2391b8155ab3784793b352825cac5161bef58"
-  },
-  {
-    "version": "4.0.1-pre.40",
-    "container_hash": "48c4213462d9408207b801339001a207d354c3df1b6423220ccfb2c0cff93e19",
-    "git_hash": "5c8f187e880efc8705306861586db2b7fd7bb5d4"
-  },
-  {
-    "version": "4.0.1-pre.41",
-    "container_hash": "9854c77880ffbbefc8d831eb0c2980156c36ed5285909c4eca16e9d7aeb7f5d2",
-    "git_hash": "cbd8c2e521afab3ca6f1c36d876cb8060be7b1a7"
-  },
-  {
-    "version": "4.0.1-pre.42",
-    "container_hash": "729347dde5f6cbb9be9e3c1de5da5a4648e6cd88eace92b2e5e9c8f7fe60d581",
-    "git_hash": "26c44a612b1e6a8b923edd04259cbe8f4b0e2a5c"
-  },
-  {
-    "version": "4.0.1-pre.43",
-    "container_hash": "e07cf3097ec1655011e0001c5ec9603251d737482826f04ad43e729b530757fa",
-    "git_hash": "2d52c7e297f6e0d781f91fccf5a3dab8befa1652"
-  },
-  {
-    "version": "4.0.1-pre.44",
-    "container_hash": "84a14bd268d80f2917524803409bf387cb359656603452ba0f46c40afd3f2d55",
-    "git_hash": "160369403be72ae5d0892f012676878094a68b17"
-  },
-  {
-    "version": "4.0.1-pre.45",
-    "container_hash": "7159dbe929cf7754d07df62b0d9cb4369bc5a1068e48caf49e30c64f4894d39e",
-    "git_hash": "eb2cd04daef75599ca9beeb1d67b7d76c3343de5"
-  },
-  {
-    "version": "4.0.1-pre.46",
-    "container_hash": "fa30c728864cb80cbcf36181d1d3eb7a690102a6e984f9a0dc66d35f338a0169",
-    "git_hash": "2c292ea9c606906ff0edcb3bc2d30764fd6abd75"
-  },
-  {
-    "version": "4.0.1-pre.5",
-    "container_hash": "f4959518a3efcdce162c94f47d2205274fed062cf0311c3e6f5809dcd3ce01ab",
-    "git_hash": "64cc438efac27720ce32b8ade256017217df0a5c"
-  },
-  {
-    "version": "4.0.1-pre.6",
-    "container_hash": "0b1601c062dea39a17bc3d737dc4e74ba42029feb8a0f6596d6538ce331f1761",
-    "git_hash": "a80f437115b41c9253c879f0a562cfe1416dd144"
-  },
-  {
-    "version": "4.0.1-pre.7",
-    "container_hash": "fffa420ff56a0534f397ba6754c855705e8bc6cf30e8e60e7bb3126c82450c00",
-    "git_hash": "7a8257d9e018d47e0465feef72e87ece885edbd6"
-  },
-  {
-    "version": "4.0.1-pre.8",
-    "container_hash": "3ab8c918367ec4b37448c786ae93a95af2dc2e5e45f416b8c9f7a8d16e8db9af",
-    "git_hash": "c2d6db3ccd79ffc7d9980d8e70881215359acb70"
-  },
-  {
-    "version": "4.0.1-pre.9",
-    "container_hash": "3617cd60868bf5e6e99bc2518e47b56340240033eaa9f2abd152f02b4a190182",
-    "git_hash": "f097059f2945b50b2b40b3e943c5248e55fe5115"
-  },
-  {
-    "version": "4.0.1-rc.46",
-    "container_hash": "a7ee3ca30b4ae55814898d21c04795362759615ad218563e6b5c766ba88a93a7",
-    "git_hash": "805d6466840940675c80febc0bcc01e8436695a5"
-  },
-  {
-    "version": "4.0.1-rc.47",
-    "container_hash": "1f1187cb5192bf6a1c3ae5eab092a1d34cc9fe2992b5b3dc4a735b1dac47c512",
-    "git_hash": "570680f80a7036628c9f905ffa78af496ebc24e2"
-  },
-  {
-    "version": "4.0.1-rc.48",
-    "container_hash": "eaf9595f5c2b39e14fed914b8031a94e806989f17b38b0dbb6ac8216f82fceb1",
-    "git_hash": "cc9dc481148548cb0bb967db83e95ecf99ffe42e"
-  },
-  {
-    "version": "4.0.1-rc.49",
-    "container_hash": "ea80966828318ebf1e5845b5fc29df9068197c496812b16728b8f0ff3d54a4c1",
-    "git_hash": "33f6917f11c0522b36cba15179a91570603a97c2"
-  },
-  {
-    "version": "4.0.1-rc.50",
-    "container_hash": "380a1d9180b8ed04d6da53162fce7f259f05753cb591cc22e8d1c10ebab058f5",
-    "git_hash": "22c24edc4cc5529ce03b9e3a46fc002f5d2e07b0"
-  },
-  {
-    "version": "4.0.1-rc.51",
-    "container_hash": "3d8ed914fcb2507b612c70770a75fa08bedf892300298cecf9375c14abddf7b8",
-    "git_hash": "2dfa37afd70c787854f3a04d0d17f3fa4ba57de6"
-  },
-  {
-    "version": "4.0.1-rc.52",
-    "container_hash": "c8e711f3f2bb0ded3901e4d625f02a9cd8aab4a51a5d77b3edebcadf530f2151",
-    "git_hash": "542b02d8b48b9009c490aa8d0e248754b74624b5"
-  },
-  {
-    "version": "4.0.1-rc.53",
-    "container_hash": "f1b4a95d799552930f7dbec1b8a5961d66281cfbeab7680f158bebf3af46c11c",
-    "git_hash": "b27cbb60a10df9021363f6d2edf96992de878fe7"
-  },
-  {
-    "version": "4.0.1-rc.54",
-    "container_hash": "176c5e92ccc4e16e3479bd65924baf9208f9baef10bf03ae7c5d33c37902a4a5",
-    "git_hash": "840e08c4ee29061833a4d523329217a0e69b0fba"
-  },
-  {
-    "version": "4.0.1-rc.55",
-    "container_hash": "eedd6a448e7f8613d1c5602863c9b23185e6d19bf8939509f5f5e8f45919e00f",
-    "git_hash": "a9a50e67626b240d7fc93443afb23cfd526a1133"
-  },
-  {
-    "version": "4.0.1-rc.56",
-    "container_hash": "49a5d2982adc4bd808469bd1e313783e5757f80de4fd1e0cf44343c9660c5939",
-    "git_hash": "84ff5a1d70404a5a32d68ad8258d8542f860a1c6"
-  },
-  {
-    "version": "4.0.1-rc.57",
-    "container_hash": "fba6e2c50ba503ecf2d23684d9abc0ebd9e0d4ea21dab3e9fedb6c20c3ee22d5",
-    "git_hash": "f9b5e305c5f658789b8fccf7dbf1d31a3c4e1c97"
-  },
-  {
-    "version": "4.0.1-rc.58",
-    "container_hash": "df4b409a0177f70504168457f04e42334a423fbede1a486a21ec625853e64fd5",
-    "git_hash": "d035878d6232bc27f0b7dd00d3f6b8722cabd329"
-  },
-  {
-    "version": "4.0.1-rc.59",
-    "container_hash": "6a64c02d8e2b43ad4303eabdc0a9f3ded59c581e97b1c4b5d89b0382fdab20c9",
-    "git_hash": "2373b70b81d86b874e3e64e899baf08722b8d1f8"
-  },
-  {
-    "version": "4.0.1-rc.60",
-    "container_hash": "d27919c1513b4812221dfbc6ef939ea3a32aadd268513ec51f86f4106e4bec13",
-    "git_hash": "e5e16e6f2ecc963a2024f44ebfe7ca3922ba9408"
-  },
-  {
-    "version": "4.0.1-rc.61",
-    "container_hash": "a32926489e685cef9f17b4906a87c9251a912ec591ee323582ba6a122725912d",
-    "git_hash": "4de0962c6a99abc6716e47fc6687ce270463c1a7"
-  },
-  {
-    "version": "4.0.1-rc.62",
-    "container_hash": "5c30f0251ef5cca12a69858dcb93c06ef17dd3b155043442f65b841068783032",
-    "git_hash": "c9d217bd81be50f41f0039ca4e63fad56c6fd820"
-  },
-  {
-    "version": "4.0.1-rc.63",
-    "container_hash": "1f71c3968369319d240149ae915dfa0a28330b09332d51f997f6f4650b7eea54",
-    "git_hash": "d21a177c9fa73b214a2cb85ffad6a9defc4a64c0"
-  },
-  {
-    "version": "4.0.1-rc.64",
-    "container_hash": "73af00313593649b5ecb7692882b62cd655a7d98a9c615614204eaf3713d37c8",
-    "git_hash": "4756ace2383f0ebe660533f4442421c60990ae31"
-  },
-  {
-    "version": "4.0.1-rc.65",
-    "container_hash": "fe6553e0d9671223fb6c663e9a9a9b09216a7caed2104339b95993515e3f4d82",
-    "git_hash": "f63f6782dee1ff4fbeab0c73b51b9b6c1cde7701"
-  },
-  {
-    "version": "4.0.1-rc.66",
-    "container_hash": "16508225198b27c6e3e36db92de3d5acb3b3518c081c31836e0b4dceabb586e1",
-    "git_hash": "913f6d9da611ec207da1c0eda643500786f74e01"
-  },
-  {
-    "version": "4.0.1-rc.67",
-    "container_hash": "34cb246cef292e1f54b70ea85c52b520474f7c2c8fdda99af9f2e8e4907e6f32",
-    "git_hash": "256c3368886ef8696e04480031e3a16eb62b34f4"
-  },
-  {
-    "version": "4.0.1-rc.68",
-    "container_hash": "4827c5e860c2022c9419d8872bb25943d93264ef1c05c038846129213bdf2820",
-    "git_hash": "3680fe4be170623dd5f6e8ade5cbbf128cda4a7d"
-  },
-  {
-    "version": "4.0.1-rc.69",
-    "container_hash": "3434db09c1cceb874cc40fc79ceacb2590fb31c2cfcb973444422174fe87fdf8",
-    "git_hash": "f5fd7d2c1fb7afd779e0f585b830e0f176ce41ed"
-  },
-  {
-    "version": "4.0.1-rc.70",
-    "container_hash": "867d648c0020314b73f5eef4cf9ebb5bd7de838e8987b061b0cb247168cbeb91",
-    "git_hash": "0e694e82bcd31d1acbe1aca15bbb3445066d7c61"
-  },
-  {
     "date": "2022-04-08",
     "version": "4.1.0",
     "container_hash": "9075c9581ca25ec0022c29cec352631da15b0b2754cd4ac6cf42cf36045eb81b",
     "git_hash": "c8484277a76f96d69dc089a427d90fb56dd4164b"
-  },
-  {
-    "version": "4.1.1-rc.0",
-    "container_hash": "6fb305513a4bd81b67908453560e54dc12bee157f11461c9c902c729fda4a54b",
-    "git_hash": "7d945ab9a9864ae4257ad26e91e1493a31303663"
-  },
-  {
-    "date": "2022-04-08",
-    "version": "pr-401-Add-rebuild-workflow-and-update",
-    "container_hash": "e0d7af89e6a38f4f62dbe4418a6627e2c8efde2249b289d82268291359a04c41",
-    "git_hash": "b502a12eb19f5657179b0f2cbcd902c2801f3cec"
   },
   {
     "date": "2022-04-19",
@@ -1254,24 +533,6 @@
     "git_hash": "4fefd51b9c388e0d7472f133c257df4cd1eeaeba"
   },
   {
-    "date": "2022-04-19",
-    "version": "4.1.1-rc.5",
-    "container_hash": "2f07352070f50ece1ac57021c7c46c56823d4f1067e3a273042326ec2dbce37c",
-    "git_hash": "ba4da0359322f2f62e95b574ec7f3ae7be75b13a"
-  },
-  {
-    "date": "2022-04-21",
-    "version": "4.1.1-rc.6",
-    "container_hash": "cc48ede62791dec065b4c4f6cee3c67183e9a31332b85353d4470761d1b0688a",
-    "git_hash": "60e7f90c0abdafc0c5f3ff29759b6ce70632f943"
-  },
-  {
-    "date": "2022-04-25",
-    "version": "4.1.1-rc.7",
-    "container_hash": "0dcf013bddfe0ea842811cbee4785043d906160d60e34d5aa7f0a9ca22c73eb8",
-    "git_hash": "4352ff98331a58f24697b0997577fbaf5c16508b"
-  },
-  {
     "date": "2022-04-26",
     "version": "3.1.0",
     "container_hash": "ff488bc089c60e0ff9aee11df1c4f49b83dbe5d19c1b0af7c716be2a02f3d2ee",
@@ -1306,18 +567,6 @@
     "version": "3.3.1",
     "container_hash": "57630b12708eee5870ddff988db2e80cd117ff3ac70a30927968c8bc461dac61",
     "git_hash": "4fefd51b9c388e0d7472f133c257df4cd1eeaeba"
-  },
-  {
-    "date": "2022-04-28",
-    "version": "4.1.1-rc.8",
-    "container_hash": "2dbf70c0f503c0d33d27d74e78b27b397c8fef9a44b0a49cc501febba41702b4",
-    "git_hash": "b943a3e7cc94e3ad8de9c57943a5646091fd8a4f"
-  },
-  {
-    "date": "2022-05-02",
-    "version": "4.1.1-rc.9",
-    "container_hash": "840be41ded1c7ecd3868d07f810a493ed174253c8ec84b8c1cf773e7679cf9b9",
-    "git_hash": "107325296a1910407b1edc096154fdf85da42ea8"
   },
   {
     "date": "2022-05-03",
@@ -1356,24 +605,6 @@
     "git_hash": "f857f32f9b51faa9bf98ad73fc9289be48571eb9"
   },
   {
-    "date": "2022-05-05",
-    "version": "4.1.1-rc.10",
-    "container_hash": "9f516c21c67431922051008ad2045d1f767ffe0bd7172a9643b53b4d5eeeff9e",
-    "git_hash": "7fa164387d27a65ecbd8b1691fb1fb43a62d8320"
-  },
-  {
-    "date": "2022-05-09",
-    "version": "4.1.1-rc.11",
-    "container_hash": "8bea89e37043e512c3dd266226bf5c16923c316e5e18339e2dbe2460bde99d55",
-    "git_hash": "47f6f5c55498d658e7886b563d68dd9c53b96a0e"
-  },
-  {
-    "date": "2022-05-09",
-    "version": "4.1.1-rc.12",
-    "container_hash": "3f9ee3ca8730e23d50d16fe1f29bd4cb4fca46d4453746f62fde374506f093f4",
-    "git_hash": "be2427409ac1fff2b78f37b30034c2c4c80e83ae"
-  },
-  {
     "date": "2022-05-10",
     "version": "3.1.0",
     "container_hash": "85d02956bf10849d2e351bff07c27e2f898507053461e96504defa5edf32c4ab",
@@ -1408,12 +639,6 @@
     "version": "3.3.0",
     "container_hash": "2722c5f99eefb592ea3de46158d442771990fca0a2dfcfa90c2ea0deeb4b5299",
     "git_hash": "f857f32f9b51faa9bf98ad73fc9289be48571eb9"
-  },
-  {
-    "date": "2022-05-16",
-    "version": "4.1.1-rc.13",
-    "container_hash": "303a83c8a773557eb90af2c65a2c1e71d183a93fc3f519fd24657c666da79b54",
-    "git_hash": "3dccceb0325796e6943fa63c9b5e7af4f66acd48"
   },
   {
     "date": "2022-05-17",
@@ -1452,18 +677,6 @@
     "git_hash": "4c42b4b2d1c7259c098f86715a2190e530d8003e"
   },
   {
-    "date": "2022-05-19",
-    "version": "4.1.1-rc.14",
-    "container_hash": "ef5633ea92306d93c9cbb1d90214cdc34160844774a371eba983d39d220548f9",
-    "git_hash": "4a0d761d334cfd5c3a4508092ebb863c74400e0a"
-  },
-  {
-    "date": "2022-05-23",
-    "version": "4.1.1-rc.15",
-    "container_hash": "78cfe900142302b52733c6d0f29583b96f995c6d43525320efd581ffec8bbb16",
-    "git_hash": "683eaa65dd4981682c56c512d5a51926fe60064a"
-  },
-  {
     "date": "2022-05-24",
     "version": "3.1.1",
     "container_hash": "e0e29f881d79e44b15e5f6c106ddc2329683c3398c4b123613ce82dcdfa76068",
@@ -1492,12 +705,6 @@
     "version": "3.3.0",
     "container_hash": "9e22540fa6dc2aba48f7c7d05b91dd3d965aa2406b3cd6ce5573ef7e0b4b1fd2",
     "git_hash": "f857f32f9b51faa9bf98ad73fc9289be48571eb9"
-  },
-  {
-    "date": "2022-05-27",
-    "version": "4.1.1-rc.16",
-    "container_hash": "21fb7b2c79168d2eb7f5ed3e78f27d8e14c29d60c9199fc25653071a25e45152",
-    "git_hash": "58a2aca0cc34143ed0e85cb69a1d114fcdde49ef"
   },
   {
     "date": "2022-05-31",
@@ -1536,36 +743,6 @@
     "git_hash": "4c42b4b2d1c7259c098f86715a2190e530d8003e"
   },
   {
-    "date": "2022-06-01",
-    "version": "4.1.1-rc.17",
-    "container_hash": "2364b3324eb7e00b78eb3e37a89fa9f3823c4e3038e801a5be022c3b0e4eba9e",
-    "git_hash": "38533ab0a7e6f11f3be32b6b45508764913f5fd8"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "4.1.1-rc.18-amd64",
-    "container_hash": "5123d9e710bb3ba80bc13d906392a00641fbf8d60f1b6698719db0342a60c3d7",
-    "git_hash": "6f9df75edf6e64cab8a14fa24bbd06ec58a9c430"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "4.1.1-rc.18-arm64",
-    "container_hash": "c879ad055a1ec134632c5a0655bfdcd9d5d236e4c2d2e2697ed2b9e405401270",
-    "git_hash": "6f9df75edf6e64cab8a14fa24bbd06ec58a9c430"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "4.1.1-rc.19-amd64",
-    "container_hash": "49ad4375f32bc3b89af71dfcdfed923a2251497f0d194bd292155ecd9679e3a8",
-    "git_hash": "9da7de563bec95da521b0d246071ec3366d0d852"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "4.1.1-rc.19-arm64",
-    "container_hash": "2f9d3d0e4115a3e54e0082e60188bf3344c942eaed81c60b7aeb3c9ea0dd7a9d",
-    "git_hash": "9da7de563bec95da521b0d246071ec3366d0d852"
-  },
-  {
     "date": "2022-06-03",
     "version": "4.1.1-amd64",
     "container_hash": "7ce7d630265f8fbe70851a8200d287269bf475f77715161c7fdee6ddced51d2b",
@@ -1573,33 +750,9 @@
   },
   {
     "date": "2022-06-03",
-    "version": "4.1.2-rc.0-amd64",
-    "container_hash": "25177af68fcc91b7057e5ce988c602eeb36a68b9c5641e73884bb03eb9dc539d",
-    "git_hash": "0159cfeceff7aa10d9e96e9db73d1bf8d5900a31"
-  },
-  {
-    "date": "2022-06-03",
     "version": "4.1.1-arm64",
     "container_hash": "692bd0db8c210b3d28c381105312b5240fa48a08bd56236b321e820ac96b7829",
     "git_hash": "34992c76518be4e63f666c36a56b24773fbc3d1b"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "4.1.2-rc.0-arm64",
-    "container_hash": "c4dde5074caaad2899aac35d75329caa06fe08e3ccac9a4e9d5209f286e3a8f4",
-    "git_hash": "0159cfeceff7aa10d9e96e9db73d1bf8d5900a31"
-  },
-  {
-    "date": "2022-06-06",
-    "version": "4.1.2-rc.1-amd64",
-    "container_hash": "5b4d5f2a74763efb6ad6c48e1174f60cb1d2a84197b7d13af49f806252964638",
-    "git_hash": "88314926e09cd4109dc54133c6ad7b9ad0b2444c"
-  },
-  {
-    "date": "2022-06-06",
-    "version": "4.1.2-rc.1-arm64",
-    "container_hash": "aa69a9265e005d2dd35804f7c18a0483834c879871a066895adbd7ae026092f8",
-    "git_hash": "88314926e09cd4109dc54133c6ad7b9ad0b2444c"
   },
   {
     "date": "2022-06-07",
@@ -1638,30 +791,6 @@
     "git_hash": "f857f32f9b51faa9bf98ad73fc9289be48571eb9"
   },
   {
-    "date": "2022-06-08",
-    "version": "4.1.2-rc.2-arm64",
-    "container_hash": "720759c3e26bea3425cd96bd56d2da5bbeb5b39c33134214cd0e67e772b56571",
-    "git_hash": "2348cbe3f12e97617113f54a6072ad0a948306b5"
-  },
-  {
-    "date": "2022-06-08",
-    "version": "4.1.2-rc.2-amd64",
-    "container_hash": "6e3f9fcee59eee7740241e1a7b598a40c54df8d912ad82ed3881caf6e3bc76db",
-    "git_hash": "2348cbe3f12e97617113f54a6072ad0a948306b5"
-  },
-  {
-    "date": "2022-06-09",
-    "version": "4.1.2-rc.3-arm64",
-    "container_hash": "527176fe9646e9ca0ddbb454518f7dd36cdbdd24947f8558ee247ac87600d76b",
-    "git_hash": "12852cebaa3c62cbbf70961cea7217a8130c42cb"
-  },
-  {
-    "date": "2022-06-09",
-    "version": "4.1.2-rc.3-amd64",
-    "container_hash": "4345e3494a94fbba6c5f0dc5ecc3403afc6a95710d4d52a66eb9ba66c9a4612c",
-    "git_hash": "12852cebaa3c62cbbf70961cea7217a8130c42cb"
-  },
-  {
     "date": "2022-06-14",
     "version": "3.2.0",
     "container_hash": "5583932009519f0a339f4152c6ab88a79a7392d441a9f13997ea99464773db0c",
@@ -1696,78 +825,6 @@
     "version": "3.1.1",
     "container_hash": "9da62807b688bacd98610b690d71596b45466955412a9b02aa14281bafdee00f",
     "git_hash": "55ff60b6c9bf25cd063833e9dd244cf5fd3532da"
-  },
-  {
-    "date": "2022-06-14",
-    "version": "4.1.2-rc.5-arm64",
-    "container_hash": "1b15de28fdfa3113341b68546529f84e79068330f522aef333681ffeec1530bd",
-    "git_hash": "be32a2974f6e6a6a5400619a11a7d72d86b6bea7"
-  },
-  {
-    "date": "2022-06-14",
-    "version": "4.1.2-rc.5-amd64",
-    "container_hash": "3c573525c22cc90e2512f77958a523af53118839c6e2fb832fdca35e687adc2f",
-    "git_hash": "be32a2974f6e6a6a5400619a11a7d72d86b6bea7"
-  },
-  {
-    "date": "2022-06-16",
-    "version": "4.1.2-rc.6-arm64",
-    "container_hash": "e0bffa37b1e90f21a22df151d688ed3d619dcff43d00ee953362f24eb1279be4",
-    "git_hash": "199c7c17932d73e8a3717e883488bd413916c954"
-  },
-  {
-    "date": "2022-06-16",
-    "version": "4.1.2-rc.6-amd64",
-    "container_hash": "6b2fbeef52cf47ff9b0e36e191f83982e34335479dd62260ee46f020933e6947",
-    "git_hash": "199c7c17932d73e8a3717e883488bd413916c954"
-  },
-  {
-    "date": "2022-06-16",
-    "version": "4.1.2-rc.7-arm64",
-    "container_hash": "4ec7c220036373ccd8dbd6c7762d3bf8eaa59cc7cdaa71f3b5930aa38e6e4602",
-    "git_hash": "6de30d075c20a1de5086ac3d3679653c9e33c3bb"
-  },
-  {
-    "date": "2022-06-16",
-    "version": "4.1.2-rc.7-amd64",
-    "container_hash": "82dd63aa78a917c95f0ed190e2498a3737f2e0e3cb72b3138f9d7abd0c78bd7b",
-    "git_hash": "6de30d075c20a1de5086ac3d3679653c9e33c3bb"
-  },
-  {
-    "date": "2022-06-17",
-    "version": "4.1.2-rc.8-arm64",
-    "container_hash": "79dae8fcd8e0c8cb290b7a297f7d923e43ca3b1cc2959f013aa833eeb648b65c",
-    "git_hash": "68c2a8942aa47dbfe98c1b1903694524e8fff277"
-  },
-  {
-    "date": "2022-06-17",
-    "version": "4.1.2-rc.8-amd64",
-    "container_hash": "6262a9c042555cbf616d42cf898aa30ab704d8b9a040ef5329f2eb97a83a4ff9",
-    "git_hash": "68c2a8942aa47dbfe98c1b1903694524e8fff277"
-  },
-  {
-    "date": "2022-06-17",
-    "version": "4.1.2-rc.9-arm64",
-    "container_hash": "ff2d5cf145cb56ec45d8cb666e7694cf45a15e4af774d576f4f09ee5e7bb1e8b",
-    "git_hash": "fe5ab9a25963def5374df36834b38d959a052757"
-  },
-  {
-    "date": "2022-06-17",
-    "version": "4.1.2-rc.9-amd64",
-    "container_hash": "70d324607e97308e09b5ea5d5a55fec871644e17e60459b553f4b70646b1e3bc",
-    "git_hash": "fe5ab9a25963def5374df36834b38d959a052757"
-  },
-  {
-    "date": "2022-06-20",
-    "version": "4.1.2-rc.10-arm64",
-    "container_hash": "2946b69412e50aaf3039d644c260020e2ff286117e4a87b08a893def6061f5c5",
-    "git_hash": "324ab0ab991879e90f5218a9888b42907ed489af"
-  },
-  {
-    "date": "2022-06-20",
-    "version": "4.1.2-rc.10-amd64",
-    "container_hash": "f57e03d39a476cb373a6eca27bd55a66a09ef3a90ca1f142c94f8e2582f172c0",
-    "git_hash": "324ab0ab991879e90f5218a9888b42907ed489af"
   },
   {
     "date": "2022-06-21",
@@ -1806,30 +863,6 @@
     "git_hash": "4fefd51b9c388e0d7472f133c257df4cd1eeaeba"
   },
   {
-    "date": "2022-06-23",
-    "version": "4.1.2-rc.11-arm64",
-    "container_hash": "cb203cf256fcc4fb455f6613bb3c1e71ea209653c5ec924544d3315551a5f2c8",
-    "git_hash": "11134d04fe7fc6f67dcf56fdac500837212649dd"
-  },
-  {
-    "date": "2022-06-23",
-    "version": "4.1.2-rc.11-amd64",
-    "container_hash": "7d921490005e3dc559371b4f667bccfffd4f45fe0da3b27a6df2350f81405ee9",
-    "git_hash": "11134d04fe7fc6f67dcf56fdac500837212649dd"
-  },
-  {
-    "date": "2022-06-23",
-    "version": "4.1.2-rc.12-arm64",
-    "container_hash": "b5a756948ba4856cbb3bae19159e2e0cfe8fa67cef6c989091de45134e5edb25",
-    "git_hash": "5452d02b2dddcd466b128253befd04a838d35a1b"
-  },
-  {
-    "date": "2022-06-23",
-    "version": "4.1.2-rc.12-amd64",
-    "container_hash": "d581d6a2c0ef0c6c2e900a3d218dc5f3480aa2a8bb8a7f35e26ad50377c4cd8b",
-    "git_hash": "5452d02b2dddcd466b128253befd04a838d35a1b"
-  },
-  {
     "date": "2022-06-28",
     "version": "3.1.0",
     "container_hash": "68d63164b496e550999862ecfb5792705e9bf1a3883d64231b22fbe61253cd56",
@@ -1864,42 +897,6 @@
     "version": "3.2.0",
     "container_hash": "6f052c7a608fa01992d9d7e0a3bebae52ce55b1aaf47c0b8dafed32f105f1a9d",
     "git_hash": "975b4d8ace4d51419552a28de1dbbd762949f605"
-  },
-  {
-    "date": "2022-06-30",
-    "version": "4.1.2-rc.13-arm64",
-    "container_hash": "5171c1152293699041a9f048443fd510df4419da999ed2573048b6ee00baf115",
-    "git_hash": "86d48df0f58346ff8b8b56335b9d66534adfb6a8"
-  },
-  {
-    "date": "2022-06-30",
-    "version": "4.1.2-rc.14-arm64",
-    "container_hash": "d8e01ce3ae5114fdc9e6d9ad2d5a11795462f5c73c72d014251984f40a5e5a37",
-    "git_hash": "064155f1df8f4ceec3ef6b9a65c4d4bb61de7492"
-  },
-  {
-    "date": "2022-06-30",
-    "version": "4.1.2-rc.13-amd64",
-    "container_hash": "9c92753c19d4104c5c677d1522582d9b341a521e94ce8ba422fe88f02de1c631",
-    "git_hash": "86d48df0f58346ff8b8b56335b9d66534adfb6a8"
-  },
-  {
-    "date": "2022-06-30",
-    "version": "4.1.2-rc.14-amd64",
-    "container_hash": "4019191f8370184df743b28d095d4ed3b7459e843b6f6bc3a7ae5c5adbf60ba0",
-    "git_hash": "064155f1df8f4ceec3ef6b9a65c4d4bb61de7492"
-  },
-  {
-    "date": "2022-07-04",
-    "version": "4.1.2-rc.15-amd64",
-    "container_hash": "33287d2ca81e523dc54c001a97ad76e7fee31515d3e8c9ed0b0822fa24a0dc86",
-    "git_hash": "694d9640628d9d9c48d2c2f48cb682ae27481efb"
-  },
-  {
-    "date": "2022-07-04",
-    "version": "4.1.2-rc.15-arm64",
-    "container_hash": "7ca661618f50d3db9d71c2a2c8e4a549f939e2bf700d2305f664e585d56e3f71",
-    "git_hash": "694d9640628d9d9c48d2c2f48cb682ae27481efb"
   },
   {
     "date": "2022-07-05",
@@ -1974,30 +971,6 @@
     "git_hash": "f857f32f9b51faa9bf98ad73fc9289be48571eb9"
   },
   {
-    "date": "2022-07-07",
-    "version": "4.1.2-rc.16-arm64",
-    "container_hash": "f8dc228f6bc2d335d7fe139e06ce17b67d607307173876553f6731a0fb1117f9",
-    "git_hash": "e1f31df044bce6cac1e6dddbd0db788edb0cc4c4"
-  },
-  {
-    "date": "2022-07-07",
-    "version": "4.1.2-rc.16-amd64",
-    "container_hash": "feeca71ba8973e93a321d90e48e30daceaa1045169b82256ae1d60fdc8356d64",
-    "git_hash": "e1f31df044bce6cac1e6dddbd0db788edb0cc4c4"
-  },
-  {
-    "date": "2022-07-11",
-    "version": "4.1.2-rc.17-amd64",
-    "container_hash": "3f19fb70b1372bc007d498d9fbfd830724d35f4996a9dc5127f46fde61cf994e",
-    "git_hash": "4683e2fc37ace37d74b4015087f64616423dad2b"
-  },
-  {
-    "date": "2022-07-11",
-    "version": "4.1.2-rc.17-arm64",
-    "container_hash": "c1ca1f6db45055579dabe8182575d779739b94b624bdfa16f5d0572244a566e6",
-    "git_hash": "4683e2fc37ace37d74b4015087f64616423dad2b"
-  },
-  {
     "date": "2022-07-12",
     "version": "3.0.0",
     "container_hash": "538ab6b218d543466290abdff5550ca34de4117a3b32aa9c53d33af9b3edddd2",
@@ -2032,18 +1005,6 @@
     "version": "3.3.0",
     "container_hash": "86e9de5cd5a5c409c762edce07b933149b8e87c974482b50cdb717c7bb2caa40",
     "git_hash": "f857f32f9b51faa9bf98ad73fc9289be48571eb9"
-  },
-  {
-    "date": "2022-07-14",
-    "version": "4.1.2-rc.18-arm64",
-    "container_hash": "3fc0807c333f89d4f559f25c995b9acc3a892046d0261ec5834efd04f84f5108",
-    "git_hash": "90546a49d91c7793f15fbf623c57905254054232"
-  },
-  {
-    "date": "2022-07-14",
-    "version": "4.1.2-rc.18-amd64",
-    "container_hash": "788a262b3410df04c57c7ca0c051d77c54daa9b7d1e8f8971450f4725a29ecc1",
-    "git_hash": "90546a49d91c7793f15fbf623c57905254054232"
   },
   {
     "date": "2022-07-15",
@@ -2166,18 +1127,6 @@
     "git_hash": "4fefd51b9c388e0d7472f133c257df4cd1eeaeba"
   },
   {
-    "date": "2022-07-21",
-    "version": "4.1.2-rc.19-arm64",
-    "container_hash": "689187913df800561322c89ea9a5dd2652031b9a2e634f59b85cd88d1afb0a14",
-    "git_hash": "03b15c178075604b020a035d7419e41da5a31650"
-  },
-  {
-    "date": "2022-07-21",
-    "version": "4.1.2-rc.19-amd64",
-    "container_hash": "06ed97746ceee26ce6a8fcdd7aebf15553369dda1696db579295cedf67247d56",
-    "git_hash": "03b15c178075604b020a035d7419e41da5a31650"
-  },
-  {
     "date": "2022-07-26",
     "version": "3.2.0",
     "container_hash": "34db88fc48c0eee7932432ccab6def84a93cc091978bcab40df2d91c8914aede",
@@ -2206,18 +1155,6 @@
     "version": "3.3.0",
     "container_hash": "7e86b7a3201eb78d042ff994f64bdca96d52597fc5a4863735e1712dad30b00f",
     "git_hash": "f857f32f9b51faa9bf98ad73fc9289be48571eb9"
-  },
-  {
-    "date": "2022-07-28",
-    "version": "4.1.2-rc.20-arm64",
-    "container_hash": "77f99fc789aee7c1660f5c8f54798fe5eaf436059632d3c4342ab02e2d9d779d",
-    "git_hash": "168fdce8ddb30a413a3d2cde202cf2912ff9acfa"
-  },
-  {
-    "date": "2022-07-28",
-    "version": "4.1.2-rc.20-amd64",
-    "container_hash": "409abcba34aa5b135694b917984a912d006fc35807587b96002da295837b3d31",
-    "git_hash": "168fdce8ddb30a413a3d2cde202cf2912ff9acfa"
   },
   {
     "date": "2022-08-02",
@@ -2250,66 +1187,6 @@
     "git_hash": "118403c5a0690e980e5a05aacf4b5be97b5d6ad4"
   },
   {
-    "date": "2022-08-04",
-    "version": "4.1.2-rc.21-arm64",
-    "container_hash": "609393164f2afa38d0195c9fd7c75f8e550becf8727a967302f424cb7f7a76aa",
-    "git_hash": "b45c4c2383b0130eab2d49755af790f7da386f05"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "4.1.2-rc.22-arm64",
-    "container_hash": "354b4fc18d9eeac92b0ea641ae12b283bcab6211ade5240289a39e47628663b6",
-    "git_hash": "2d09b21a8361252f634ce3fc6883938245181b54"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "4.1.2-rc.21-amd64",
-    "container_hash": "c379e431d9be0fe13f3801229ed81343d5493d00a04cbebea0c1fb38d932459d",
-    "git_hash": "b45c4c2383b0130eab2d49755af790f7da386f05"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "4.1.2-rc.22-amd64",
-    "container_hash": "493093e2d9c01f1d933f024fe3de3245dd8ec541e471877a1b72bbc892abcffa",
-    "git_hash": "2d09b21a8361252f634ce3fc6883938245181b54"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "4.1.2-rc.23-arm64",
-    "container_hash": "4b65ce2e89f34f048880d38b7bd3640c85e107e36135844acbbcea5b7be27a95",
-    "git_hash": "fc999fa27c90b37652d736e637248b81016beac7"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "4.1.2-rc.24-arm64",
-    "container_hash": "f79305b6a5776b072b2c012962026d619a0ee2f01b2291c626d6b77228187f86",
-    "git_hash": "035f9a7729dab2a641c44a491c7886acbde74105"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "4.1.2-rc.23-amd64",
-    "container_hash": "2c4d38244d56dc83b3f6a83b2a043bd97e8ec873c8be8dacd75d97ac045dd926",
-    "git_hash": "fc999fa27c90b37652d736e637248b81016beac7"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "4.1.2-rc.24-amd64",
-    "container_hash": "ed1d9f48d0428040c9404a6663338bbdcd0aafd6e4883ca6125888bd0a6f7016",
-    "git_hash": "035f9a7729dab2a641c44a491c7886acbde74105"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "4.1.2-rc.25-arm64",
-    "container_hash": "e17101850cf699172991267cda8c412f33fd5f40752e6c7c3417b8d701bdddb6",
-    "git_hash": "a129beb968445727fdbb70740676d39b47f91e62"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "4.1.2-rc.25-amd64",
-    "container_hash": "e30f630359eed58d1d312c31c9cb54ac181b2151dffe899ebdb0f61d6f5ae2cc",
-    "git_hash": "a129beb968445727fdbb70740676d39b47f91e62"
-  },
-  {
     "date": "2022-08-09",
     "version": "3.2.0",
     "container_hash": "69bc0feb20edd9ee211bcbff09b2ecf9c2b42965b00dc2e2b660d26171bf2875",
@@ -2338,54 +1215,6 @@
     "version": "3.3.1",
     "container_hash": "7ec2bd9900d861df06e3e5d611d0cdf74b8ee23deca518e92fb07e91c89ee4cc",
     "git_hash": "4fefd51b9c388e0d7472f133c257df4cd1eeaeba"
-  },
-  {
-    "date": "2022-08-10",
-    "version": "4.1.2-rc.26-arm64",
-    "container_hash": "bad0a33a3de41bff454bb649ca76fca35c489465856b9ef5fb841aab19f1a79e",
-    "git_hash": "eb88d417e7622034986a0f50bcda121a5297d0c8"
-  },
-  {
-    "date": "2022-08-10",
-    "version": "4.1.2-rc.27-amd64",
-    "container_hash": "5472af7232a76849cdd5229ff5664b309e0e24609af37a4313a65068e2da80d9",
-    "git_hash": "516831f3cb5d2faba6e7806851082188b9156b4c"
-  },
-  {
-    "date": "2022-08-10",
-    "version": "4.1.2-rc.26-amd64",
-    "container_hash": "eb79c85a1ebf5677ba5746eef0234c6b94a6252df554611a8c3be772c4b4a8a4",
-    "git_hash": "eb88d417e7622034986a0f50bcda121a5297d0c8"
-  },
-  {
-    "date": "2022-08-10",
-    "version": "4.1.2-rc.27-arm64",
-    "container_hash": "0c38111dd0970f5b56d418b18be2e04fde89b06f7d07489ea2afca2b93280ddf",
-    "git_hash": "516831f3cb5d2faba6e7806851082188b9156b4c"
-  },
-  {
-    "date": "2022-08-11",
-    "version": "4.1.2-rc.28-amd64",
-    "container_hash": "7400c4d3b4d65a8e818c4aac150087e874ccbfcc1e7096dbc59d43925cbdde1b",
-    "git_hash": "a16bd8fc85600cbcbb216bd312cdc21671bed4c0"
-  },
-  {
-    "date": "2022-08-11",
-    "version": "4.1.2-rc.28-arm64",
-    "container_hash": "ec960b99e5763e356203ac93c766dadad068bce5caa5065296cc0ea1851d5c84",
-    "git_hash": "a16bd8fc85600cbcbb216bd312cdc21671bed4c0"
-  },
-  {
-    "date": "2022-08-15",
-    "version": "4.1.2-rc.29-amd64",
-    "container_hash": "641c4ed23b9739ae09e786680792157dfad708ad1442e7c574d95f57100e9215",
-    "git_hash": "1c523ea4d6ef6f3715881211013ee998685accac"
-  },
-  {
-    "date": "2022-08-15",
-    "version": "4.1.2-rc.29-arm64",
-    "container_hash": "1b3727c5b251854689ad9635bc84c79598b0b50d6b05b7d6b970a3a0d1cb9015",
-    "git_hash": "1c523ea4d6ef6f3715881211013ee998685accac"
   },
   {
     "date": "2022-08-16",
@@ -2418,18 +1247,6 @@
     "git_hash": "4fefd51b9c388e0d7472f133c257df4cd1eeaeba"
   },
   {
-    "date": "2022-08-19",
-    "version": "4.1.2-rc.30-arm64",
-    "container_hash": "dd84923045294184cd0840711b07f7ec84babebc0b730a044d1f7bcdd944203f",
-    "git_hash": "153bcba96af056e5c33cca25b70e7af1b60a1c7b"
-  },
-  {
-    "date": "2022-08-19",
-    "version": "4.1.2-rc.30-amd64",
-    "container_hash": "51367222beb5da701507e9bb0f8d17e948e8732d2575f65afea7c879fee92dad",
-    "git_hash": "153bcba96af056e5c33cca25b70e7af1b60a1c7b"
-  },
-  {
     "date": "2022-08-23",
     "version": "3.1.1",
     "container_hash": "f973b644650c7aa34c10aeda11e705e1d78eb4b253ca4444371974d37563eeec",
@@ -2458,18 +1275,6 @@
     "version": "3.3.1",
     "container_hash": "c0aef46e40651b6469081814d8487aa28a1f191a0235d0970175e5d8779e5c19",
     "git_hash": "4fefd51b9c388e0d7472f133c257df4cd1eeaeba"
-  },
-  {
-    "date": "2022-08-25",
-    "version": "4.1.2-rc.31-arm64",
-    "container_hash": "4ac6567738ab963364e4145573284eddc1b1267e2a68b58d9c59cf04285ddeb3",
-    "git_hash": "b991dd00b527ae5473ea0d44f7c7b3ba0508a453"
-  },
-  {
-    "date": "2022-08-25",
-    "version": "4.1.2-rc.31-amd64",
-    "container_hash": "4779d71ea13459110f18b506e04cc752a53bdf48ab0022696fc4b8efa4c40a4a",
-    "git_hash": "b991dd00b527ae5473ea0d44f7c7b3ba0508a453"
   },
   {
     "date": "2022-08-30",
@@ -2502,66 +1307,6 @@
     "git_hash": "118403c5a0690e980e5a05aacf4b5be97b5d6ad4"
   },
   {
-    "date": "2022-08-30",
-    "version": "4.1.2-rc.32-arm64",
-    "container_hash": "45be7ecc70087d8a3cbd851993544cb145d7123e929e95c486f32992d69997cd",
-    "git_hash": "e9b419167541d529b7171447ebb047b2b2be5aed"
-  },
-  {
-    "date": "2022-08-30",
-    "version": "4.1.2-rc.32-amd64",
-    "container_hash": "d040b61acfae55a9279ae9eabe2355001791adcaaf2c0f35951f7a6c5a549e4a",
-    "git_hash": "e9b419167541d529b7171447ebb047b2b2be5aed"
-  },
-  {
-    "date": "2022-09-01",
-    "version": "4.1.2-rc.33-arm64",
-    "container_hash": "04cae3e6b13d0efab6dd5175fe302ef799f48e37b48e46ad9cf0ecc1b44871fb",
-    "git_hash": "8cb5ac9e52e5b8b429a081689fedd9e7cf5fa00f"
-  },
-  {
-    "date": "2022-09-01",
-    "version": "4.1.2-rc.33-amd64",
-    "container_hash": "db600c9b59797b9c18f728e7f214a6b26b6d92453438b01e7fb66d06a956f7dd",
-    "git_hash": "8cb5ac9e52e5b8b429a081689fedd9e7cf5fa00f"
-  },
-  {
-    "date": "2022-09-01",
-    "version": "4.1.2-rc.34-amd64",
-    "container_hash": "6f18ca871d25ed4071ee2b11c8edf07b4f2ceeb3ddefe958ff568be4260006ec",
-    "git_hash": "2951f3e8d9ae87db09bf0fbdb5693997cf83a459"
-  },
-  {
-    "date": "2022-09-01",
-    "version": "4.1.2-rc.35-amd64",
-    "container_hash": "9fa7f8a63bbf3463dcb3f47870618c7600c4d87f8982349bafcb7bbb97c21865",
-    "git_hash": "c2bad91c7bf3b5f1b914d39d2d9fa4d1e4ac5699"
-  },
-  {
-    "date": "2022-09-01",
-    "version": "4.1.2-rc.35-arm64",
-    "container_hash": "78f4e34c26274212f01d8029c291eb18a8b06af40f36d08b725ac3b30dd68d90",
-    "git_hash": "c2bad91c7bf3b5f1b914d39d2d9fa4d1e4ac5699"
-  },
-  {
-    "date": "2022-09-02",
-    "version": "4.1.2-rc.34-arm64",
-    "container_hash": "d68ed6f32e622e744404462d5ff1194d3421da7d857ecc5704b01547b632545c",
-    "git_hash": "2951f3e8d9ae87db09bf0fbdb5693997cf83a459"
-  },
-  {
-    "date": "2022-09-02",
-    "version": "4.1.2-rc.36-arm64",
-    "container_hash": "6135901240f91a8065786f1d8fc352cb507691eaa03e2f6852af1ec06981bd15",
-    "git_hash": "45512ed41e14d8c2b3d8d23b9be95ca69abb72bd"
-  },
-  {
-    "date": "2022-09-02",
-    "version": "4.1.2-rc.36-amd64",
-    "container_hash": "05c64a5c6579c09d7125111ee1e0b107728fe1038dc2fbb9354d9bf261d9a5c6",
-    "git_hash": "45512ed41e14d8c2b3d8d23b9be95ca69abb72bd"
-  },
-  {
     "date": "2022-09-06",
     "version": "3.2.0",
     "container_hash": "7f2a0606c756e6caf44932d797010af3df8b8eefbc4a0573def346ef7265e8f2",
@@ -2590,78 +1335,6 @@
     "version": "3.3.0",
     "container_hash": "72c68cce4d75b7d85080793ccdf0a0a797f0860dc630d29fa74be8a7456a3f9c",
     "git_hash": "f857f32f9b51faa9bf98ad73fc9289be48571eb9"
-  },
-  {
-    "date": "2022-09-07",
-    "version": "4.1.2-rc.37-amd64",
-    "container_hash": "cde2c81dcba8978e1c65f9ae2aebe140782481a4668bb221eda844944eb4251a",
-    "git_hash": "8a56de707fde44f77ab61700cba1f64b7825d594"
-  },
-  {
-    "date": "2022-09-07",
-    "version": "4.1.2-rc.37-arm64",
-    "container_hash": "ec840b29e9dcdc6cb05f47d096e5fe43dd5e6bd2714d5eab816d9a952128e747",
-    "git_hash": "8a56de707fde44f77ab61700cba1f64b7825d594"
-  },
-  {
-    "date": "2022-09-08",
-    "version": "4.1.2-rc.38-amd64",
-    "container_hash": "c522027b055da007b9783ce1576f8aa373dfc9a5e3352e0c5d2f80fd68d451f0",
-    "git_hash": "bb887aa5b4649ece0447e42ccb557ee1f32d31c8"
-  },
-  {
-    "date": "2022-09-08",
-    "version": "4.1.2-rc.38-arm64",
-    "container_hash": "3ee6c3c63cc0c6b9b0bb2c807ee3dcd1d2a51d5dbcb4257f3414aca3deec66e1",
-    "git_hash": "bb887aa5b4649ece0447e42ccb557ee1f32d31c8"
-  },
-  {
-    "date": "2022-09-08",
-    "version": "4.1.2-rc.39-arm64",
-    "container_hash": "ed8acd1873e2ab3e434b733735918a5d899c7ce21409e630f23a5e2a14e6345d",
-    "git_hash": "080dcc5f5c1db906fd1e322ae04fb6765a0f04b3"
-  },
-  {
-    "date": "2022-09-09",
-    "version": "4.1.2-rc.40-amd64",
-    "container_hash": "605f2e4db1e9b00a5ac681dcdb2bacd784675df9a6b5c4698c834d315212db7f",
-    "git_hash": "0b4a11a7b9cb9cc2fbad8c31b28710295b8f10b9"
-  },
-  {
-    "date": "2022-09-09",
-    "version": "4.1.2-rc.39-amd64",
-    "container_hash": "a064d5f3c0e327aa3755bd1b736a441315cee94c1eb4da353e8dfc98bfc6a353",
-    "git_hash": "080dcc5f5c1db906fd1e322ae04fb6765a0f04b3"
-  },
-  {
-    "date": "2022-09-08",
-    "version": "4.1.2-rc.40-arm64",
-    "container_hash": "b91f01613ab66881c762265bb171d4d70dc86ff94976db54f6b51d6c925d951b",
-    "git_hash": "0b4a11a7b9cb9cc2fbad8c31b28710295b8f10b9"
-  },
-  {
-    "date": "2022-09-09",
-    "version": "4.1.2-rc.41-arm64",
-    "container_hash": "68467162b38155d5e2ee2133df703488ae264bb3ba8a1df5e6a80b7aa8820f66",
-    "git_hash": "2d4a6abc4c2793098889feb1786a4c311ab0d5f2"
-  },
-  {
-    "date": "2022-09-09",
-    "version": "4.1.2-rc.41-amd64",
-    "container_hash": "077a727ff032d03cebbf971f8417cb9566edd308315e76f4c9b2978b0db2eccc",
-    "git_hash": "2d4a6abc4c2793098889feb1786a4c311ab0d5f2"
-  },
-  {
-    "date": "2022-09-12",
-    "version": "4.1.2-rc.42-amd64",
-    "container_hash": "06d40cf43f090c71850f59b4b43b65117f50e01dcef2d23d57c008511e67d6f0",
-    "git_hash": "905e1ef326ee6792d71779bdc73e352be5c81cf9"
-  },
-  {
-    "date": "2022-09-12",
-    "version": "4.1.2-rc.42-arm64",
-    "container_hash": "8675594b856b2ff8a551a0b548b6980ffb0b5d1bdbf831f4100f3bfd457642f9",
-    "git_hash": "905e1ef326ee6792d71779bdc73e352be5c81cf9"
   },
   {
     "date": "2022-09-13",
@@ -2694,30 +1367,6 @@
     "git_hash": "7ff82cc47a8a7c1e626a0278709573701852b6fd"
   },
   {
-    "date": "2022-09-15",
-    "version": "4.1.2-rc.43-amd64",
-    "container_hash": "3d7d2c244b2fafab5b3fa762b603abc18f36e07cc8f29747b6d0037324eb9a03",
-    "git_hash": "1ae7ea767b23988e5a0a4b9a87e029c5c271f9e1"
-  },
-  {
-    "date": "2022-09-15",
-    "version": "4.1.2-rc.44-amd64",
-    "container_hash": "ab69a3fb5ccd47954339802a987f88e2a3b7f4f357805c501ecaafc04621e622",
-    "git_hash": "9d867328c89a244e381c65f38b15d361680eaed8"
-  },
-  {
-    "date": "2022-09-16",
-    "version": "4.1.2-rc.45-amd64",
-    "container_hash": "b78a8755d82694a0d25fa4579394a48c813f6866e717c61787a65662bb97c7e3",
-    "git_hash": "cf946569e90887de7bef39436b8cdb8f1ddb9b9d"
-  },
-  {
-    "date": "2022-09-16",
-    "version": "4.1.2-rc.45-arm64",
-    "container_hash": "af18cb9e12e8d969468fa08e218524c6d91167e8cbfd2e16e803c6a73427f08b",
-    "git_hash": "cf946569e90887de7bef39436b8cdb8f1ddb9b9d"
-  },
-  {
     "date": "2022-09-20",
     "version": "3.1.0",
     "container_hash": "33192ef23e0a4e62ba3eac4fede4a2ce222a6437a7218f1949d167ac1675bc49",
@@ -2746,54 +1395,6 @@
     "version": "3.1.1",
     "container_hash": "90c69db644c9812d1e6de60bd303d4fbfa964a66fdd87ce5256ad67a335d2b2c",
     "git_hash": "1fc620a77011174b98f78177cefc7258dae95830"
-  },
-  {
-    "date": "2022-09-22",
-    "version": "4.1.2-rc.46-arm64",
-    "container_hash": "93b67ed7cbcc5d63d53a60b690cfccc79655f6729b176b8c9d26dc53820b8651",
-    "git_hash": "0cc6861cd6c4ecb4b69a502c92614bb13536fbf3"
-  },
-  {
-    "date": "2022-09-22",
-    "version": "4.1.2-rc.46-amd64",
-    "container_hash": "5f1a742b0e81f2343a618e378e98f88593bd6ed6903227be17fe3f9f9c0ca462",
-    "git_hash": "0cc6861cd6c4ecb4b69a502c92614bb13536fbf3"
-  },
-  {
-    "date": "2022-09-22",
-    "version": "4.1.2-rc.47-arm64",
-    "container_hash": "546051920086c636c9d81fcdc4e0db323921fe87edfc20a4d5c3bff7b110d1db",
-    "git_hash": "9c122ad28d32520257fa966435a0eb9926e73169"
-  },
-  {
-    "date": "2022-09-22",
-    "version": "4.1.2-rc.47-amd64",
-    "container_hash": "4d2c4dd1759e39f62be58c85af9f92bb5e349442159724eb444632201ff961ba",
-    "git_hash": "9c122ad28d32520257fa966435a0eb9926e73169"
-  },
-  {
-    "date": "2022-09-22",
-    "version": "4.1.2-rc.48-amd64",
-    "container_hash": "f8b24c878d012c3c043b8a0498622458fc606401c2e2007ec55e8d02e54c327e",
-    "git_hash": "15dd09660421673991eafdcaa1bf413f354c34f5"
-  },
-  {
-    "date": "2022-09-22",
-    "version": "4.1.2-rc.48-arm64",
-    "container_hash": "e9f2be4cbae2610b6dc06563a63cc7e94711d09345385a6f367f335b14b4510d",
-    "git_hash": "15dd09660421673991eafdcaa1bf413f354c34f5"
-  },
-  {
-    "date": "2022-09-26",
-    "version": "4.1.2-rc.49-arm64",
-    "container_hash": "934b793d6dcc783db9511724d108a3d5c126b5f884c54af1e680b2e243e69a65",
-    "git_hash": "69a89af271531bca778f50e45c7631baef73ec91"
-  },
-  {
-    "date": "2022-09-26",
-    "version": "4.1.2-rc.49-amd64",
-    "container_hash": "23d0856fdf53cc8a874993ea115d359e8ec256b0d434bb334e62500a07c7ef35",
-    "git_hash": "69a89af271531bca778f50e45c7631baef73ec91"
   },
   {
     "date": "2022-09-27",
@@ -2826,66 +1427,6 @@
     "git_hash": "118403c5a0690e980e5a05aacf4b5be97b5d6ad4"
   },
   {
-    "date": "2022-09-29",
-    "version": "4.1.2-rc.50-arm64",
-    "container_hash": "3434a49330a776d07fc7ba87d62f371730571a3826ce6e31579ed75245ca7e0c",
-    "git_hash": "9cd33eb636970ad8e409468c30326c0b2d67635f"
-  },
-  {
-    "date": "2022-09-29",
-    "version": "4.1.2-rc.51-arm64",
-    "container_hash": "dd3579364ca38c3a17b4abc767b1d6f5b55c2c0c3d82c5219c31aeb40312ac22",
-    "git_hash": "38eb4693714c4356893ed5c8eb45c0d7187420d5"
-  },
-  {
-    "date": "2022-09-29",
-    "version": "4.1.2-rc.51-amd64",
-    "container_hash": "12f8e72044f63ed8632f9a3a7a31aa16be5e8b20c9f18f23c9d11055ed21a648",
-    "git_hash": "38eb4693714c4356893ed5c8eb45c0d7187420d5"
-  },
-  {
-    "date": "2022-09-29",
-    "version": "4.1.2-rc.50-amd64",
-    "container_hash": "3eed45ef21d9e912440cc5033422cdbd4cb61aae0e4ceba95579f1df1382b399",
-    "git_hash": "9cd33eb636970ad8e409468c30326c0b2d67635f"
-  },
-  {
-    "date": "2022-09-29",
-    "version": "4.1.2-rc.52-amd64",
-    "container_hash": "171004d5879fbfa727dfc4e50c9b0466705f6f3ec52176f0f151b55aff46a6c8",
-    "git_hash": "7580073cbefc08ab2cb0cccf616cb5fe46fc457e"
-  },
-  {
-    "date": "2022-09-29",
-    "version": "4.1.2-rc.52-arm64",
-    "container_hash": "e98b409f529452ba5da850572562a1edea90f06eeeccc6d8111d5f7c670a7885",
-    "git_hash": "7580073cbefc08ab2cb0cccf616cb5fe46fc457e"
-  },
-  {
-    "date": "2022-09-30",
-    "version": "4.1.2-rc.53-arm64",
-    "container_hash": "2e27d98f1a29bda72f03a46c5b8f34ddf6130c20dbc0ce571d1db92395851a14",
-    "git_hash": "0246910af04b258e75e19a42b8529da68c23a0b6"
-  },
-  {
-    "date": "2022-09-30",
-    "version": "4.1.2-rc.53-amd64",
-    "container_hash": "2caf7ab6c68b203314509898319869fd80050b6589dd0da725ea107d3b6575d6",
-    "git_hash": "0246910af04b258e75e19a42b8529da68c23a0b6"
-  },
-  {
-    "date": "2022-10-03",
-    "version": "4.1.2-rc.54-arm64",
-    "container_hash": "bd2e8aec9024a71a3183d82816e123dd1e01b314058aba13b83c229db94a2dc5",
-    "git_hash": "6f09f083fff3fc05a248f8ee7088bf38b4969aa4"
-  },
-  {
-    "date": "2022-10-03",
-    "version": "4.1.2-rc.54-amd64",
-    "container_hash": "26dfcbf14326c9992046a9ebf1d491213684f2a71f9fb184e787e79d2c4f7bf7",
-    "git_hash": "6f09f083fff3fc05a248f8ee7088bf38b4969aa4"
-  },
-  {
     "date": "2022-10-04",
     "version": "3.1.0",
     "container_hash": "859a31de8d26f0400665dca8dd5b9f42ead4cb825b749385f458e6cf0e30b438",
@@ -2916,18 +1457,6 @@
     "git_hash": "1fc620a77011174b98f78177cefc7258dae95830"
   },
   {
-    "date": "2022-10-10",
-    "version": "4.1.2-rc.55-amd64",
-    "container_hash": "ce01a69c3f070dea1baa36b8514861f5c83a68b56d3daea59acca567466a6822",
-    "git_hash": "ac3a5fae61436fa15f1c861ec2f89b918c473f2f"
-  },
-  {
-    "date": "2022-10-10",
-    "version": "4.1.2-rc.55-arm64",
-    "container_hash": "a4ed038c95e8b9022de8ff0e68c117916b9af00ef97cc800cd2b79f16bddcfc7",
-    "git_hash": "ac3a5fae61436fa15f1c861ec2f89b918c473f2f"
-  },
-  {
     "date": "2022-10-11",
     "version": "3.1.1",
     "container_hash": "61dab137b7911aa3bc04900bb083167e04f43a5002ed078e9de8bc0dddd07e18",
@@ -2950,18 +1479,6 @@
     "version": "3.2.0",
     "container_hash": "6729d0b7ea363e7a3d1419b8dd196d3fea1a99e41b6870a6c80c3047f46f4e36",
     "git_hash": "118403c5a0690e980e5a05aacf4b5be97b5d6ad4"
-  },
-  {
-    "date": "2022-10-17",
-    "version": "4.1.2-rc.57-amd64",
-    "container_hash": "a19c8b922b0499753463c5d66152719aea80da65b928ae809dc34fa5f28bd800",
-    "git_hash": "c57bf993c5150d39619c510731f54c0fb107b8f2"
-  },
-  {
-    "date": "2022-10-17",
-    "version": "4.1.2-rc.57-arm64",
-    "container_hash": "59e0d8d5be8c8aace0510b0e514e65a8da4eb0ff1c4129b881d0311e34b358f7",
-    "git_hash": "c57bf993c5150d39619c510731f54c0fb107b8f2"
   },
   {
     "date": "2022-10-18",
@@ -3012,30 +1529,6 @@
     "git_hash": "f857f32f9b51faa9bf98ad73fc9289be48571eb9"
   },
   {
-    "date": "2022-10-25",
-    "version": "4.1.2-rc.58-amd64",
-    "container_hash": "d551cc931c3e69fb1e0b26c9647c8cac84ba6335414c3eb3916e05deeb835b94",
-    "git_hash": "7b573b4e36b536f1e5d458609a93716c363746fd"
-  },
-  {
-    "date": "2022-10-25",
-    "version": "4.1.2-rc.58-arm64",
-    "container_hash": "e2533db1c57f44065237157ac6b42a95b3ebb1916fab4d539278c30abd47214e",
-    "git_hash": "7b573b4e36b536f1e5d458609a93716c363746fd"
-  },
-  {
-    "date": "2022-10-27",
-    "version": "4.1.2-rc.59-arm64",
-    "container_hash": "72ea8ef04fe201b457e1572b954d583081ead65e923e79a88a3d6d44b25eccb6",
-    "git_hash": "53888708c4fccc363ae7f4d3a664290e6f168eb4"
-  },
-  {
-    "date": "2022-10-27",
-    "version": "4.1.2-rc.59-amd64",
-    "container_hash": "5fc49513a976fae71f25226cf24f54dd23ee64e941e4d46f14c002555e8875b3",
-    "git_hash": "53888708c4fccc363ae7f4d3a664290e6f168eb4"
-  },
-  {
     "date": "2022-11-01",
     "version": "3.1.1",
     "container_hash": "753cfbe9be4a002633e24ca724be33f9b2d89eac1c18225caa3e8a19605e3a3a",
@@ -3064,18 +1557,6 @@
     "version": "3.3.0",
     "container_hash": "8a111e6a18eacd79d6bb434fa2b4d7217c5e6c764c63bde7973b21c4e5e8c7e4",
     "git_hash": "f857f32f9b51faa9bf98ad73fc9289be48571eb9"
-  },
-  {
-    "date": "2022-11-07",
-    "version": "4.1.2-rc.60-amd64",
-    "container_hash": "3ad1215346dc7f53230bf6c28b9e4649d7ca86820569a0f266cdb53383f589f5",
-    "git_hash": "620b844123fbe63619e0e8b5a2b9bd0cb6a50b6a"
-  },
-  {
-    "date": "2022-11-07",
-    "version": "4.1.2-rc.60-arm64",
-    "container_hash": "08fc153bb0a2a1f17ec9c1fe31e7ca4f4cd99cddfef207831322f2b2210fa239",
-    "git_hash": "620b844123fbe63619e0e8b5a2b9bd0cb6a50b6a"
   },
   {
     "date": "2022-11-08",
@@ -3138,42 +1619,6 @@
     "git_hash": "4fefd51b9c388e0d7472f133c257df4cd1eeaeba"
   },
   {
-    "date": "2022-11-18",
-    "version": "4.1.2-rc.61-arm64",
-    "container_hash": "ccf5049f640ffc31419dd96d3df8e49909764bb605dcd00e401706b11fd96a9c",
-    "git_hash": "b003f7bb50451d067b9106a423f7b203cf5f1f53"
-  },
-  {
-    "date": "2022-11-18",
-    "version": "4.1.2-rc.61-amd64",
-    "container_hash": "ae8f7b325f9b3fd7aa97a186b56b564be059290a99de459d102dabf13e8e5f49",
-    "git_hash": "b003f7bb50451d067b9106a423f7b203cf5f1f53"
-  },
-  {
-    "date": "2022-11-21",
-    "version": "4.1.2-rc.62-amd64",
-    "container_hash": "4701fe6dcf8403f10993a9813ac967c59449e1815995a55df8af08c48fba230b",
-    "git_hash": "f7548e43635f86248515a1c18044cf5352a7eda1"
-  },
-  {
-    "date": "2022-11-21",
-    "version": "4.1.2-rc.62-arm64",
-    "container_hash": "385c4d1b057f5bda089d83d9360dba1dc0c37046aec267f66fe9c8018f0dd787",
-    "git_hash": "f7548e43635f86248515a1c18044cf5352a7eda1"
-  },
-  {
-    "date": "2022-11-21",
-    "version": "4.1.2-rc.63-amd64",
-    "container_hash": "d167e508a5e1d88d0811e51662d2524240e80274e5b7b5dff2b174e345669b0d",
-    "git_hash": "9993fb0610ee8a6566ab4c34c37b1798ce2e87b5"
-  },
-  {
-    "date": "2022-11-21",
-    "version": "4.1.2-rc.63-arm64",
-    "container_hash": "af8d4712b796994e0ddbd0e1713d6a93994b8bd61c5d0f932eca908b44bd3048",
-    "git_hash": "9993fb0610ee8a6566ab4c34c37b1798ce2e87b5"
-  },
-  {
     "date": "2022-11-22",
     "version": "3.2.0",
     "container_hash": "b5fc2e99288ce8968faccdfd850082cd59db0af595a07489848ec6b8e9f67a1a",
@@ -3202,30 +1647,6 @@
     "version": "3.1.1",
     "container_hash": "df7b212c265b4ff4bd5cbec747f0fff12a86f7652480317b87e682722d8517c7",
     "git_hash": "1fc620a77011174b98f78177cefc7258dae95830"
-  },
-  {
-    "date": "2022-11-28",
-    "version": "4.1.2-rc.64-amd64",
-    "container_hash": "0fb571fbc7971db916b1ed5a8133d4212d34a3b143c9d8baf569066613ce8b54",
-    "git_hash": "2fdf55bc88023c1fedf34eca0e4b48845edc2ac8"
-  },
-  {
-    "date": "2022-11-28",
-    "version": "4.1.2-rc.64-arm64",
-    "container_hash": "16b4b7694f8ad62f5db295b12e580667d2187df704d0bf4d6d3a66d2827c718b",
-    "git_hash": "2fdf55bc88023c1fedf34eca0e4b48845edc2ac8"
-  },
-  {
-    "date": "2022-11-28",
-    "version": "4.1.2-rc.65-amd64",
-    "container_hash": "6033d48ffcce7a2bcb042db084eff7423cb3a319947a57ea698f109ccfd27df3",
-    "git_hash": "4357a92e89bc772a491fa85aa8394c89544680b0"
-  },
-  {
-    "date": "2022-11-28",
-    "version": "4.1.2-rc.65-arm64",
-    "container_hash": "4bae43674259cc64568850b5e7b3fc890f402d6996f7e28a75f4a09a08d56793",
-    "git_hash": "4357a92e89bc772a491fa85aa8394c89544680b0"
   },
   {
     "date": "2022-11-29",
@@ -3258,42 +1679,6 @@
     "git_hash": "1fc620a77011174b98f78177cefc7258dae95830"
   },
   {
-    "date": "2022-12-01",
-    "version": "4.1.2-rc.66-arm64",
-    "container_hash": "848e8dd39598886b161ba1d98e95eb123755866119b2750fb74d135032a79666",
-    "git_hash": "dc8d1ea1e8df526c7bc4e1872203f2eed0a99396"
-  },
-  {
-    "date": "2022-12-01",
-    "version": "4.1.2-rc.66-amd64",
-    "container_hash": "ceb656578423842ae640e1c1ae33251d59d128dc4deb47ebc1590ce03127d34c",
-    "git_hash": "dc8d1ea1e8df526c7bc4e1872203f2eed0a99396"
-  },
-  {
-    "date": "2022-12-01",
-    "version": "4.1.2-rc.67-arm64",
-    "container_hash": "1ec904e95e97f965c8a65843bde1bae30a16e9cb1f08b81f8f1d3275d1fbfa5a",
-    "git_hash": "9093799948b0dc427ec11e117eb1c4a2ce27c2f8"
-  },
-  {
-    "date": "2022-12-02",
-    "version": "4.1.2-rc.67-amd64",
-    "container_hash": "6be7952c5ef48d98597cd12a32ffd9936633bcb518a8f5154dfa26f8f59ca0a3",
-    "git_hash": "9093799948b0dc427ec11e117eb1c4a2ce27c2f8"
-  },
-  {
-    "date": "2022-12-05",
-    "version": "4.1.2-rc.68-amd64",
-    "container_hash": "916bcd511455dd19eecb9f1e9674b220a5360ae0f0ef993843b558edc067ccf3",
-    "git_hash": "c686519b9d15173866012215bb180a513e3e79a2"
-  },
-  {
-    "date": "2022-12-05",
-    "version": "4.1.2-rc.68-arm64",
-    "container_hash": "d6ee80718656382462366f18c09e10e1b9ff24846e095f5f1c5b01c2310ed1c0",
-    "git_hash": "c686519b9d15173866012215bb180a513e3e79a2"
-  },
-  {
     "date": "2022-12-06",
     "version": "3.1.0",
     "container_hash": "4f59b4170a64fb85d69bfc15885626143cdb68122fa9e61c9389d1ae88f0d2bb",
@@ -3322,54 +1707,6 @@
     "version": "3.1.1",
     "container_hash": "a909c3426e76c7a7f5e8207aaf159be177babda848154c1acbe663349eac57e4",
     "git_hash": "1fc620a77011174b98f78177cefc7258dae95830"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "4.1.2-rc.69-amd64",
-    "container_hash": "dd0c6cb20085c3ba26b0e7bf62b4a9438a7bc01d520050775b8f463b06b841f1",
-    "git_hash": "a00b5bbb0d1e01ee36f32b2e6e31324e76d2763b"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "4.1.2-rc.69-arm64",
-    "container_hash": "5cab106197e1b83223f31a34d06174012a1f53c282eae455ae33e02231cf11a8",
-    "git_hash": "a00b5bbb0d1e01ee36f32b2e6e31324e76d2763b"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "4.1.2-rc.70-amd64",
-    "container_hash": "b736b47ffe6cc4e06813e6d1e5d159bac0883140a684047d686a097646c48011",
-    "git_hash": "964ee8390ab42017662d500e5474192c58a25fd6"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "4.1.2-rc.70-arm64",
-    "container_hash": "145c1e97307930a288f9ae6bbca0717d8b97a253761664585e58a8cd399e6ccc",
-    "git_hash": "964ee8390ab42017662d500e5474192c58a25fd6"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "4.1.2-rc.71-amd64",
-    "container_hash": "5029a67d67084e7869cab6e3de579bcaa5b32227d96ab0dd2cc87a242322575d",
-    "git_hash": "bb17a2a0f65881a1f820442cfa1a6c3e1e6d37b5"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "4.1.2-rc.71-arm64",
-    "container_hash": "be4eea184e7f4d44c2bce8b02da5c99c49e4e6164004e0a10257e724e3e760b4",
-    "git_hash": "bb17a2a0f65881a1f820442cfa1a6c3e1e6d37b5"
-  },
-  {
-    "date": "2022-12-12",
-    "version": "4.1.2-rc.72-amd64",
-    "container_hash": "c84323e54c629998edcacf40dd27dd7293a9bf57a994ce951ec2170f59da0727",
-    "git_hash": "4e038438e34fe89a24b68cd076db14e8df254ba6"
-  },
-  {
-    "date": "2022-12-12",
-    "version": "4.1.2-rc.72-arm64",
-    "container_hash": "36e2cd9d17d65429555022948522f083214d46972306863c157376f0589d4a8c",
-    "git_hash": "4e038438e34fe89a24b68cd076db14e8df254ba6"
   },
   {
     "date": "2022-12-13",
@@ -3402,18 +1739,6 @@
     "git_hash": "4fefd51b9c388e0d7472f133c257df4cd1eeaeba"
   },
   {
-    "date": "2022-12-15",
-    "version": "4.1.2-rc.73-amd64",
-    "container_hash": "7934c7bd7d708fbf276a2d3e97269c0ac177c90d8b96057fb422bff6d8bde677",
-    "git_hash": "90bd45d9384c54ff9985474720e47be979068f3b"
-  },
-  {
-    "date": "2022-12-15",
-    "version": "4.1.2-rc.73-arm64",
-    "container_hash": "802f88da3a405d392217e9ed7b8d2be3b3c7a3c3518b0353745974eb2c703c09",
-    "git_hash": "90bd45d9384c54ff9985474720e47be979068f3b"
-  },
-  {
     "date": "2022-12-27",
     "version": "3.1.0",
     "container_hash": "7e29ce29c632dd13ef85421d5207d077374f6c17d78aa414332573ff02d4cd1f",
@@ -3442,54 +1767,6 @@
     "version": "3.3.1",
     "container_hash": "23dab131db46249a55702771928b85a96eee922426f3f9eaeb2aef8c59ab3337",
     "git_hash": "4fefd51b9c388e0d7472f133c257df4cd1eeaeba"
-  },
-  {
-    "date": "2022-12-27",
-    "version": "4.1.2-rc.74-arm64",
-    "container_hash": "ebd680014fe9ee4d2ac1bda3a308663ea69f9c9110b64fe9f2e4b2aaafeefd97",
-    "git_hash": "c5b7b88335855357a497cbeb6bf1ece16c1da6de"
-  },
-  {
-    "date": "2022-12-27",
-    "version": "4.1.2-rc.74-amd64",
-    "container_hash": "df71912aa85f8b250a9c32c5807c5fbebfab99278636d67d42a8afd7e98a8f0f",
-    "git_hash": "c5b7b88335855357a497cbeb6bf1ece16c1da6de"
-  },
-  {
-    "date": "2022-12-27",
-    "version": "4.1.2-rc.75-arm64",
-    "container_hash": "7e288b2115dedda38a48174e2f305fb09602e4e4c9744e30d39a7de2a4515d6b",
-    "git_hash": "b148e872c07a76c0432e6402c3ea4c25d94791ab"
-  },
-  {
-    "date": "2022-12-27",
-    "version": "4.1.2-rc.75-amd64",
-    "container_hash": "a4014737c7db74f2bca8359e352b200dbbfeccf0b0a58cdc9155f6f77a100578",
-    "git_hash": "b148e872c07a76c0432e6402c3ea4c25d94791ab"
-  },
-  {
-    "date": "2022-12-27",
-    "version": "4.1.2-rc.76-arm64",
-    "container_hash": "8f96babf79b2de6426e55333338e7ea945b3af7b991adb18eb3283e81a91bf5b",
-    "git_hash": "b79072ae27e245b00e23735aabe941f5adef07c8"
-  },
-  {
-    "date": "2022-12-27",
-    "version": "4.1.2-rc.76-amd64",
-    "container_hash": "731b5dceb3993d944935154a7a819ca50f13f054ef843cac23673d59b11f838b",
-    "git_hash": "b79072ae27e245b00e23735aabe941f5adef07c8"
-  },
-  {
-    "date": "2023-01-09",
-    "version": "4.1.2-rc.79-arm64",
-    "container_hash": "15b31bfcf026172dda78a6e6846cffb81334bcb810005147a56f51eb3896308b",
-    "git_hash": "0215a27fa7b7659f569bcd69db91eba2dbc78618"
-  },
-  {
-    "date": "2023-01-09",
-    "version": "4.1.2-rc.79-amd64",
-    "container_hash": "eda73855ed9922d6f08d1c253b12591ce31f113843dc51a1ae02bd0736ad7083",
-    "git_hash": "0215a27fa7b7659f569bcd69db91eba2dbc78618"
   },
   {
     "date": "2023-01-10",
@@ -3522,300 +1799,6 @@
     "git_hash": "4fefd51b9c388e0d7472f133c257df4cd1eeaeba"
   },
   {
-    "date": "2023-01-10",
-    "version": "4.1.2-rc.80-arm64",
-    "container_hash": "b344f653ec43e5e6c68b51120ab6d81b5b548e870f59204107f9c72781c0c3a9",
-    "git_hash": "4effcf546f0d9c8fd62cf8f4937e2e9c9c84349f"
-  },
-  {
-    "date": "2023-01-10",
-    "version": "4.1.2-rc.80-amd64",
-    "container_hash": "24c055c508bb4f20a6e4b2e0eeb3ad5f1ba5a0c59d373b1829aca75036a99f6d",
-    "git_hash": "4effcf546f0d9c8fd62cf8f4937e2e9c9c84349f"
-  },
-  {
-    "date": "2023-01-13",
-    "version": "4.1.2-rc.81-amd64",
-    "container_hash": "e7c4c680f943e6a9bacd7422fd52c9054a81e995ba0280208ca499f146da55fd",
-    "git_hash": "b6524014e50821d22b172f65d46712c1216f6d7c"
-  },
-  {
-    "date": "2023-01-13",
-    "version": "4.1.2-rc.81-arm64",
-    "container_hash": "9d7aa54c6f06b86fb5d3c8389a81183605da685e7e33c334e0316a0e7d7ec84f",
-    "git_hash": "b6524014e50821d22b172f65d46712c1216f6d7c"
-  },
-  {
-    "date": "2023-01-13",
-    "version": "4.1.2-rc.82-amd64",
-    "container_hash": "4d8f9f31cf96147907186af927858134279ae36d625c97f9a5c399428794b877",
-    "git_hash": "c42ca76d54e2f7dced1f7a380197b1ea015f7b54"
-  },
-  {
-    "date": "2023-01-13",
-    "version": "4.1.2-rc.83-amd64",
-    "container_hash": "0b24a4d239ba73e15e4345e3d2abd85c8d3ca349cbe6b4cfe01525a66dae7071",
-    "git_hash": "406803eefce5008557e95e178b9c00b4578d8113"
-  },
-  {
-    "date": "2023-01-13",
-    "version": "4.1.2-rc.83-arm64",
-    "container_hash": "7ab0e20b6d8b3bda3bb40122d85c256e55eef19345f3e1e0226403e7cfbdce4f",
-    "git_hash": "406803eefce5008557e95e178b9c00b4578d8113"
-  },
-  {
-    "date": "2023-01-19",
-    "version": "4.1.2-rc.84-arm64",
-    "container_hash": "cde1d0822182b2b78915070391b68bb721c3039592f92dd102b8926837a3be61",
-    "git_hash": "7ac0714e0909293090af7bd2c0c921eb743cd779"
-  },
-  {
-    "date": "2023-01-19",
-    "version": "4.1.2-rc.84-amd64",
-    "container_hash": "5b429a5863cacb4356267a74f5280755ea7437079e199f4adcf1a04455b3b631",
-    "git_hash": "7ac0714e0909293090af7bd2c0c921eb743cd779"
-  },
-  {
-    "date": "2023-01-26",
-    "version": "4.1.2-rc.85-arm64",
-    "container_hash": "1b9429e3b2c9749d160466282141d228b568adf54ba9bd0896006afa3eb062b6",
-    "git_hash": "e0de8972695a363311fe0641b70609b9305446e0"
-  },
-  {
-    "date": "2023-01-26",
-    "version": "4.1.2-rc.85-amd64",
-    "container_hash": "4a3eddcec0a6981ba91a7b563501a6bff53866eddc59ec3de4cb9dae26f75c85",
-    "git_hash": "e0de8972695a363311fe0641b70609b9305446e0"
-  },
-  {
-    "date": "2023-01-26",
-    "version": "4.1.2-rc.86-arm64",
-    "container_hash": "7a2cbee59990fb036117ed2d4587177c04a04acc098afcefd16ecfc66016cf71",
-    "git_hash": "ad745ef25cf88bebe2ea756b2ceb492945bae279"
-  },
-  {
-    "date": "2023-01-26",
-    "version": "4.1.2-rc.86-amd64",
-    "container_hash": "8add765166f19678c97262761f5807cb63703f1d61eed690082430e59cc12f3c",
-    "git_hash": "ad745ef25cf88bebe2ea756b2ceb492945bae279"
-  },
-  {
-    "date": "2023-02-01",
-    "version": "4.1.2-rc.87-arm64",
-    "container_hash": "0bdd74b83ab4f0fc748fd82c63e6e163c83282fde3b024134807039a971592a5",
-    "git_hash": "0541c02b07535dd8a1520731ffe4e65614e75fac"
-  },
-  {
-    "date": "2023-02-01",
-    "version": "4.1.2-rc.87-amd64",
-    "container_hash": "5258761df2a03bff376a9af2b4372377c3ed9eb1a1d4a20f3a36f646c4963d92",
-    "git_hash": "0541c02b07535dd8a1520731ffe4e65614e75fac"
-  },
-  {
-    "date": "2023-02-02",
-    "version": "4.1.2-rc.88-arm64",
-    "container_hash": "84b201617dce6f2681eef013a88027e110992dcfc89df5251efc6a2aaa2a702d",
-    "git_hash": "2f22d060af249c010fdfc589611320d35f4f9ad7"
-  },
-  {
-    "date": "2023-02-02",
-    "version": "4.1.2-rc.88-amd64",
-    "container_hash": "f7c5b809dddb84c81baad16680eb52a87f4e513d30353799103eca1167d1ddf1",
-    "git_hash": "2f22d060af249c010fdfc589611320d35f4f9ad7"
-  },
-  {
-    "date": "2023-02-06",
-    "version": "4.1.2-rc.89-amd64",
-    "container_hash": "c3cd01fc0fd0b35f6212123b02f47b5d63c34caebff58982140cb8921622d6a4",
-    "git_hash": "91ad21642426a07b0dbb964ebca0114e10cbb196"
-  },
-  {
-    "date": "2023-02-06",
-    "version": "4.1.2-rc.89-arm64",
-    "container_hash": "8f9df82c3acc67c427bd4f166a8a9891f92ddf433828e6c12ed0a34a9d9db874",
-    "git_hash": "91ad21642426a07b0dbb964ebca0114e10cbb196"
-  },
-  {
-    "date": "2023-02-07",
-    "version": "4.1.2-rc.90-arm64",
-    "container_hash": "38fbacc9126ddf1431e958fffd6b4203a33af28172784b50877857a22a4ac506",
-    "git_hash": "7df1cff2d4f698ca64d98915d6aa925dd361b8a5"
-  },
-  {
-    "date": "2023-02-07",
-    "version": "4.1.2-rc.90-amd64",
-    "container_hash": "2b0a28cd454d985134adc8b518f01238c624643acd51526ba99ae93a98e5805e",
-    "git_hash": "7df1cff2d4f698ca64d98915d6aa925dd361b8a5"
-  },
-  {
-    "date": "2023-02-09",
-    "version": "4.1.2-rc.91-amd64",
-    "container_hash": "22a2927df326849c04aaa9ddc260a7157c38a465f2201358be83cd57419265c4",
-    "git_hash": "9194050f60bc4968151b1688f66cf717469804b7"
-  },
-  {
-    "date": "2023-02-09",
-    "version": "4.1.2-rc.91-arm64",
-    "container_hash": "d57e3f6863d41e8716bc9ce3bc3889d20c19d8bfd0a36eac66927bfd29aaf04a",
-    "git_hash": "9194050f60bc4968151b1688f66cf717469804b7"
-  },
-  {
-    "date": "2023-02-10",
-    "version": "4.1.2-rc.92-arm64",
-    "container_hash": "7954797dcec98147e2ee4a3b9e6366911d03c99d93c6af7c38746c4fb3f57acd",
-    "git_hash": "5e76ddf2be59e8840180cb621a023f3f7993125d"
-  },
-  {
-    "date": "2023-02-11",
-    "version": "4.1.2-rc.92-amd64",
-    "container_hash": "7998a23a230ee2a8e3406072ca5e7b73050c56800f55c40eeea4c1dab2526c46",
-    "git_hash": "5e76ddf2be59e8840180cb621a023f3f7993125d"
-  },
-  {
-    "date": "2023-02-13",
-    "version": "4.1.2-rc.93-amd64",
-    "container_hash": "d91b63c644764add00cb61a311c4aff1c1e709f877b28d78a42308b5f1087572",
-    "git_hash": "8f34c0753f99869d164183850816646764a525c0"
-  },
-  {
-    "date": "2023-02-20",
-    "version": "4.1.2-rc.94-amd64",
-    "container_hash": "3a1fb57270a8587ef0d17707f69039a5eeeb1c49d1ac227537be6235a29db317",
-    "git_hash": "ecaf2b0913d41dafefe8b55aba6769e3873916aa"
-  },
-  {
-    "date": "2023-02-23",
-    "version": "4.1.2-rc.95-arm64",
-    "container_hash": "090be0bd665309e89e8c5b806f99176457a9ef17c891f8b371a57bd517927920",
-    "git_hash": "a05a2d492a580985444d82dcab7b9e852e868a65"
-  },
-  {
-    "date": "2023-02-23",
-    "version": "4.1.2-rc.95-amd64",
-    "container_hash": "a5f36d60d7dc292444861b1391abfe7b3f587df3658e47e6bee1647cb6bb317c",
-    "git_hash": "a05a2d492a580985444d82dcab7b9e852e868a65"
-  },
-  {
-    "date": "2023-03-02",
-    "version": "4.1.2-rc.96-arm64",
-    "container_hash": "ce66b61d920802028816571167af94e4ab259ad2ca7118ee0733859ea0ae0cb7",
-    "git_hash": "6b9ccfc5f8a3155e7d01d48da2edf449c26430f8"
-  },
-  {
-    "date": "2023-03-02",
-    "version": "4.1.2-rc.96-amd64",
-    "container_hash": "50562c8d8357bf6971141214d4ada1536b0c05c2ccb5e9e741246ca28a4cfc03",
-    "git_hash": "6b9ccfc5f8a3155e7d01d48da2edf449c26430f8"
-  },
-  {
-    "date": "2023-03-03",
-    "version": "4.1.2-rc.97-arm64",
-    "container_hash": "5d1fdf09ec4810913ed2bcbb6eaef161e464fd34e3900c66542bacf388a669e9",
-    "git_hash": "708bd344e22f11353105affc4558e7ab33d3e838"
-  },
-  {
-    "date": "2023-03-03",
-    "version": "4.1.2-rc.97-amd64",
-    "container_hash": "d874c61f8b15456c54f0774d953172373bb68954d59492939d0d66f71bca031f",
-    "git_hash": "708bd344e22f11353105affc4558e7ab33d3e838"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "4.1.2-rc.98-arm64",
-    "container_hash": "c9b49bccb2782acf3a7b18e5fbb250415eee1786dcde9342182867f19b20126b",
-    "git_hash": "8e6453ea593761f6ad34aebe4b8ab357e60c8b27"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "4.1.2-rc.100-amd64",
-    "container_hash": "44196620721f0c7b3c62ee21252f8fe9b8d543e7ca5c78c3348c2cdc87d309fd",
-    "git_hash": "679d510d1e7f8b70bbb3d7bc3aa871ff2be9a104"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "4.1.2-rc.99-amd64",
-    "container_hash": "18b3458ad5f97711b4e62c96c92132573235ac971ce9465286ab7710e73c7e28",
-    "git_hash": "730fb95d0194a7bf81e2c3989deb279c5e90421f"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "4.1.2-rc.98-amd64",
-    "container_hash": "9c2a8209d8c5f53c1ba12fa2b9aa16b8306885c8d64bc0f304d18f8688970ea3",
-    "git_hash": "8e6453ea593761f6ad34aebe4b8ab357e60c8b27"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "4.1.2-rc.99-arm64",
-    "container_hash": "3e8985ef8987eede950f872334644c534edba0394c2072ed1252a9e695c0a649",
-    "git_hash": "730fb95d0194a7bf81e2c3989deb279c5e90421f"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "4.1.2-rc.101-amd64",
-    "container_hash": "c5d9fdb48944ede89409a00ad1633b0e20c249616a0be41f956da5e7e07e5198",
-    "git_hash": "040ff5676be95a25f01bf52c0995c2fbd88e6dee"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "4.1.2-rc.102-amd64",
-    "container_hash": "63067df578e07ae4fdf525e0228f164249dd9c14f61e96ffe7a8398d22481eaf",
-    "git_hash": "ba7e8e0076d29f100d6dad2b58d553c7c8a46184"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "4.1.2-rc.101-arm64",
-    "container_hash": "8831bba4dc991b9e83b982bb72c2fc0cacd1bc40a2bd3ccc5804eb4cb74debb9",
-    "git_hash": "040ff5676be95a25f01bf52c0995c2fbd88e6dee"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "4.1.2-rc.102-arm64",
-    "container_hash": "b49fb2e51e7067ff960557d4ed4caa2ff3c6a2c1cff8368b476e21b8d7e3ada9",
-    "git_hash": "ba7e8e0076d29f100d6dad2b58d553c7c8a46184"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "4.1.2-rc.100-arm64",
-    "container_hash": "a28b4afb651af507900af58fb518b1687cdcf1a24e1e74729fd7441d405d4f1d",
-    "git_hash": "679d510d1e7f8b70bbb3d7bc3aa871ff2be9a104"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "4.1.2-rc.103-amd64",
-    "container_hash": "9aa442f2f9c0b0e1127d83ea424c9edf1be078e4e86c395f31587a29f0697310",
-    "git_hash": "2c9d084ab43480ebb63a00d46054b7adbded808f"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "4.1.2-rc.104-amd64",
-    "container_hash": "81d182b4943ebff4dea63b15120e357cd93e2621cf7b306bf9357419e7ac564e",
-    "git_hash": "379255b8ae905cc612c93d7152cb6827cdf9cfa3"
-  },
-  {
-    "date": "2023-03-16",
-    "version": "4.1.2-rc.103-arm64",
-    "container_hash": "d968af8c84ad263da41c79f660ca5cf2dade49e4d04618b9255c716e2b2aacf9",
-    "git_hash": "2c9d084ab43480ebb63a00d46054b7adbded808f"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "4.1.2-rc.105-amd64",
-    "container_hash": "35549efc98d15a93df35b032997840390cb442fadf99efcec82949b95a3083d7",
-    "git_hash": "6b5111c3ab0365200811028439fd725196f1d258"
-  },
-  {
-    "date": "2023-03-16",
-    "version": "4.1.2-rc.104-arm64",
-    "container_hash": "47fae9d7e3ed8aca22a378cdc8ea1f8b720172947b8383875025f67fea0ba639",
-    "git_hash": "379255b8ae905cc612c93d7152cb6827cdf9cfa3"
-  },
-  {
-    "date": "2023-03-16",
-    "version": "4.1.2-rc.105-arm64",
-    "container_hash": "e0af331b98fb293549f81ea371f25f08663347ec652894f836d8d6dc2857648c",
-    "git_hash": "6b5111c3ab0365200811028439fd725196f1d258"
-  },
-  {
     "date": "2023-03-17",
     "version": "4.1.1-arm64",
     "container_hash": "6521225fc020e8c34d1077dd11728f72beeb16cc1df8a4c52a6d886ed7276f76",
@@ -3838,60 +1821,6 @@
     "version": "4.1.0-arm64",
     "container_hash": "f9a8bf1fc06dafe2ae2ad15528714b679ce03be9a0bed417a4dd71051b0fccc4",
     "git_hash": "d506d591dabf9f3ec79c5df0cb02427be5175236"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "4.1.2-rc.106-arm64",
-    "container_hash": "47166b98e0cc7866b528dc77652b862fa84c5aca49150934acd26aa87710ff9b",
-    "git_hash": "582739c83f205fb0f2b439e9da367e0d578efd18"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "4.1.2-rc.106-amd64",
-    "container_hash": "b11c3e69a70fb951964417a68d396d41307404d44e4e1251e2295ebe8d8e085c",
-    "git_hash": "582739c83f205fb0f2b439e9da367e0d578efd18"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "4.1.2-rc.107-arm64",
-    "container_hash": "2035b0bcb89982461e5bb204af48e0d6026de9cef286c61affa6a439ac98bc7d",
-    "git_hash": "6811ce8c248845c8bd26b39a9f3191fd1883e122"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "4.1.2-rc.107-amd64",
-    "container_hash": "486e6911bcbeff30a35cf229bfa8067ab1dbede9fbc4366dab1a77414fa9f2a2",
-    "git_hash": "6811ce8c248845c8bd26b39a9f3191fd1883e122"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "4.1.2-rc.108-arm64",
-    "container_hash": "1049bde7401642769d65b17c0591e440bea64b32e86aa0938c2f26f3a16b65f1",
-    "git_hash": "5fdc08eb37f647d5c192b4442790b5f99b5c4019"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "4.1.2-rc.108-amd64",
-    "container_hash": "27a26c405c733e8899eb4033c2ea9593caa5737a713964ff59fc564b6122badb",
-    "git_hash": "5fdc08eb37f647d5c192b4442790b5f99b5c4019"
-  },
-  {
-    "date": "2023-03-20",
-    "version": "4.1.2-rc.109-amd64",
-    "container_hash": "b19a2f14fd51214e364e70ba1174e711eca1933a1b992783162ac671884ee7bc",
-    "git_hash": "bc6ad6d69fb8ee6c91b583111e8754c3570b12cb"
-  },
-  {
-    "date": "2023-03-20",
-    "version": "4.1.2-rc.110-amd64",
-    "container_hash": "dfd51b0a40649a81ec2a456eab6516a9a30f7fe323ff0414cbd8b7e1d1f3cf83",
-    "git_hash": "348b0eb31aebee705203c72d8a6e036d9a78c15b"
-  },
-  {
-    "date": "2023-03-20",
-    "version": "4.1.2-rc.110-arm64",
-    "container_hash": "fe72af4f879889bc93bee67d5802e4011c2e19767ed4359c8c606f77e7368215",
-    "git_hash": "348b0eb31aebee705203c72d8a6e036d9a78c15b"
   },
   {
     "date": "2023-03-21",
@@ -3919,18 +1848,6 @@
   },
   {
     "date": "2023-03-21",
-    "version": "4.1.2-rc.111-amd64",
-    "container_hash": "f8d67b274b097f810596b4e2945ab5a685f95a3d41b9b4fe08c29a10d7d39d5d",
-    "git_hash": "bd44aef838b1eeaa4808f7720ee2bf1d267d3979"
-  },
-  {
-    "date": "2023-03-21",
-    "version": "4.1.2-rc.111-arm64",
-    "container_hash": "35e990cdd71bc97f5b3f8924f4936e0cda90705b8dfbf2ea4db90fd039266894",
-    "git_hash": "bd44aef838b1eeaa4808f7720ee2bf1d267d3979"
-  },
-  {
-    "date": "2023-03-21",
     "version": "4.2.0-amd64",
     "container_hash": "c6944790cd6f239a370467830176967760f66ccb865a049bd808632c7a053c22",
     "git_hash": "47dde7af28d0620568288c020717f08c1e8af0a6"
@@ -3940,18 +1857,6 @@
     "version": "4.2.0-arm64",
     "container_hash": "d727e53e16acd628af0beae260ea483364728f01a12f61243aeb353211dd4c67",
     "git_hash": "47dde7af28d0620568288c020717f08c1e8af0a6"
-  },
-  {
-    "date": "2023-03-27",
-    "version": "4.2.1-rc.0-amd64",
-    "container_hash": "9c51d0b518ce355144974a3083556b41553bf1d6aa8872589ac90f295ede9756",
-    "git_hash": "71134046f062aaf09408a1d872786d3f2ec8037c"
-  },
-  {
-    "date": "2023-03-27",
-    "version": "4.2.1-rc.0-arm64",
-    "container_hash": "cffa3925738b5c64c564460866853663b6eb6b7bf11e022cc0cd36c3b0a14ba7",
-    "git_hash": "71134046f062aaf09408a1d872786d3f2ec8037c"
   },
   {
     "date": "2023-03-28",
@@ -3988,30 +1893,6 @@
     "version": "4.1.0-arm64",
     "container_hash": "f9a8bf1fc06dafe2ae2ad15528714b679ce03be9a0bed417a4dd71051b0fccc4",
     "git_hash": "d506d591dabf9f3ec79c5df0cb02427be5175236"
-  },
-  {
-    "date": "2023-03-31",
-    "version": "4.2.1-rc.1-amd64",
-    "container_hash": "6db0d22219e2ba3d5379af56dd3994bfeb027a75951af0ed3252b1be5042da57",
-    "git_hash": "2f9bf374f8470b03e2033d7206600699cf8abcad"
-  },
-  {
-    "date": "2023-03-31",
-    "version": "4.2.1-rc.1-arm64",
-    "container_hash": "a6115a4acc3f7db7fa5e9588f7579811856cd72b8be71eeb426dc43d3277fc1d",
-    "git_hash": "2f9bf374f8470b03e2033d7206600699cf8abcad"
-  },
-  {
-    "date": "2023-04-03",
-    "version": "4.2.1-rc.2-amd64",
-    "container_hash": "718c2d50dba59f0c64b80a46b1d9547ab4d2fa3f3ff254e282ad7cee83fb1b9f",
-    "git_hash": "5a0f0698fc9fa0cbc4e1be25879b602f1802a353"
-  },
-  {
-    "date": "2023-04-03",
-    "version": "4.2.1-rc.2-arm64",
-    "container_hash": "c873bfe029a4e324271254acc48c6363177c0de2c675905ef3ceb32fdf911235",
-    "git_hash": "5a0f0698fc9fa0cbc4e1be25879b602f1802a353"
   },
   {
     "date": "2023-04-04",
@@ -4122,18 +2003,6 @@
     "git_hash": "e55e09511cf40fc9d932afb4984c0028acb4b998"
   },
   {
-    "date": "2023-04-24",
-    "version": "4.3.0-rc.0-arm64",
-    "container_hash": "bd0fc2d572a2232d1cf90e43039d044074bfa4addbe0190908e18a9d5ce6020d",
-    "git_hash": "4b2f2ece758f1fc7f6402602af2a190c1557f9ab"
-  },
-  {
-    "date": "2023-04-24",
-    "version": "4.3.0-rc.0-amd64",
-    "container_hash": "f252c1a2ab6f3256f712fa9f490939ff2135c8e19226f7538588ee1dca41f182",
-    "git_hash": "4b2f2ece758f1fc7f6402602af2a190c1557f9ab"
-  },
-  {
     "date": "2023-05-05",
     "version": "4.3.0-amd64",
     "container_hash": "37809232e5f90de44cc2156556865ea3ef95deb38fdaa4b08e35aad33e15fd05",
@@ -4144,65 +2013,5 @@
     "version": "4.3.0-arm64",
     "container_hash": "2ba4fb01b84f53f35dc437fde86c586aa7f2d47e146bc1c7b14fe394e83c7a26",
     "git_hash": "6288cc5177aaea518c2df212fd4376deb94258ac"
-  },
-  {
-    "date": "2023-05-24",
-    "version": "4.3.1-rc.0-amd64",
-    "container_hash": "94fd170e61a7e1f733ddcb3b07fe535740f22df9d2fde2d91930befa688f7353",
-    "git_hash": "73b39f01ec959949c28197c2c5f74f529ecb4e08"
-  },
-  {
-    "date": "2023-05-24",
-    "version": "4.3.1-rc.0-arm64",
-    "container_hash": "b2a4781b3c539b9b6faaceb60711983482c56150cbd195ea45bd38616eb14885",
-    "git_hash": "73b39f01ec959949c28197c2c5f74f529ecb4e08"
-  },
-  {
-    "date": "2023-05-26",
-    "version": "4.3.1-rc.1-amd64",
-    "container_hash": "71f3f56e9db513d3358febd923891d0e1833a8fcbc45b028dbd2d9b247297ad8",
-    "git_hash": "d47bcdfa6176ae53f54bf4f7955955d939e0071d"
-  },
-  {
-    "date": "2023-05-26",
-    "version": "4.3.1-rc.1-arm64",
-    "container_hash": "81e0dcf359f3fe547c3588506aab9680b87b78a87875e58207f42e3759625d9d",
-    "git_hash": "d47bcdfa6176ae53f54bf4f7955955d939e0071d"
-  },
-  {
-    "date": "2023-06-08",
-    "version": "4.3.1-rc.2-amd64",
-    "container_hash": "80b0ddd182628e3eb00ec2ed457b31b87b36ba43f15f98c49f9d89d87d53b15a",
-    "git_hash": "c3ea80591049e7682493afa97974849fd838fe6b"
-  },
-  {
-    "date": "2023-06-08",
-    "version": "4.3.1-rc.2-arm64",
-    "container_hash": "cebc311bde3bc416cdca15b7ee17df617393d764cb7856038531a70587076a6e",
-    "git_hash": "c3ea80591049e7682493afa97974849fd838fe6b"
-  },
-  {
-    "date": "2023-08-07",
-    "version": "4.3.1-rc.3-amd64",
-    "container_hash": "22e10d6b657fed917c7bd7024f8d84abe82f2047e3b32999eb9e287d90e4b15f",
-    "git_hash": "e3d66d94b79392cca00774c5879631a265c89e21"
-  },
-  {
-    "date": "2023-08-07",
-    "version": "4.3.1-rc.3-arm64",
-    "container_hash": "98afc3f355a69cb8f0ad3c57430713716e64f6b00480f8177963698c8ffec4cf",
-    "git_hash": "e3d66d94b79392cca00774c5879631a265c89e21"
-  },
-  {
-    "date": "2023-08-16",
-    "version": "4.3.1-rc.4-arm64",
-    "container_hash": "55b5f50273addaddb4a99d3a3cbbce3785056e69a11f61bb5dbbd66dd36b96dc",
-    "git_hash": "e2ba2f86834582310ef21011ddf06bbfc56c451f"
-  },
-  {
-    "date": "2023-08-16",
-    "version": "4.3.1-rc.4-amd64",
-    "container_hash": "405ab6489ea49d38b936b02c2945d9d15f930279efaed3ae474bffd50266aabb",
-    "git_hash": "e2ba2f86834582310ef21011ddf06bbfc56c451f"
   }
 ]

--- a/tenant-security-proxy.json
+++ b/tenant-security-proxy.json
@@ -1,85 +1,5 @@
 [
   {
-    "version": "2.0.0-1",
-    "container_hash": "2985b27fa554fe23ab17b80ac2a673f8822215b97e4c82f9d959647def053940",
-    "git_hash": "f52ecdefd3149cd7bbda7f0418eb89a3afc38d5c"
-  },
-  {
-    "version": "2.0.0-1",
-    "container_hash": "2b0e434196538f5fee76f6da8d561dfc0bb0c994f869d0cabb1ec9757bd59565",
-    "git_hash": "60e878553bdcd357947c8deaa6c896248f4fd4b0"
-  },
-  {
-    "version": "2.0.0-1",
-    "container_hash": "d82d87ae65118e8183eae9de8cfa65539e210b99d07e7dfae12aab0ad0dc01a8",
-    "git_hash": "fab8da93e389478b9abcfddb9a86a154c0a6916e"
-  },
-  {
-    "version": "2.0.0-1",
-    "container_hash": "e624d7d4470cee6fe9d57af916d3e74bfc1e180158cbe324e387782bb129d8be",
-    "git_hash": "fab8da93e389478b9abcfddb9a86a154c0a6916e"
-  },
-  {
-    "version": "2.0.1-1",
-    "container_hash": "230cdacb4cc97b6f563e7e67ac18a0c0bb6ec2a546731fc23a84995c3c39682b",
-    "git_hash": "590c2222ffe34e23bcf67aecb685c5c468b6ad38"
-  },
-  {
-    "version": "2.0.1-1",
-    "container_hash": "2493750ee2a04bcc56a61fa3be3161258bd0981cde8db86ace54f06bde210937",
-    "git_hash": "590c2222ffe34e23bcf67aecb685c5c468b6ad38"
-  },
-  {
-    "version": "2.0.1-1",
-    "container_hash": "318b53c10c888eb29b6c7aaf4175974b6f0f86473a6a79e69e5a2e5d608711a4",
-    "git_hash": "4235a182268d23ba9bc638af768050ca23992025"
-  },
-  {
-    "version": "2.0.1-1",
-    "container_hash": "63eb24f4be6267aeac8fb6957144194c86569fb1deffeb7e4ab8b623a58e2373",
-    "git_hash": "df6cc2aa070405fec9581d04e934cc7acaea370e"
-  },
-  {
-    "version": "2.0.2-1",
-    "container_hash": "48fd29c7f8014235d74b0a2e203d731b7da3807a400b15c651744d6d6bde0cfd",
-    "git_hash": "8774d27970e0a7b35e604ed3ba6ea86f0207a0f6"
-  },
-  {
-    "version": "2.0.2-1",
-    "container_hash": "8523ffaedd664e23f8d0a8bab130b04acb8536db012b695e2f7e40a22f717038",
-    "git_hash": "8774d27970e0a7b35e604ed3ba6ea86f0207a0f6"
-  },
-  {
-    "version": "2.0.2-1",
-    "container_hash": "9e7112cbc0f63dde68598ff6d185721b7d6e93b0cc0685cab6630bf0e8c710b8",
-    "git_hash": "740849866aac38071c14f6357c15045f55575787"
-  },
-  {
-    "version": "2.0.2-1",
-    "container_hash": "ead2507e20bf9c0468ce01db10ccc132fdb78d4e2abdd211fc9d09f3a632667a",
-    "git_hash": "77946041dd266f209f3b13526ec0425a7b09b50b"
-  },
-  {
-    "version": "2.1.0-1",
-    "container_hash": "442e7d47dd4d98cc839cc2e8fa72ffe5d8aa1b7f355ae95175f039a96b045432",
-    "git_hash": "cdd5a5fb6ab56d53e199b6958f87883034a5e9bc"
-  },
-  {
-    "version": "2.1.0-1",
-    "container_hash": "8d7c397200d030bd24902cb763ca762f7912050c83dc67f8a6a7cfa458bc9e8d",
-    "git_hash": "a7152b0f136252a380c07f4a4557aa80e40107af"
-  },
-  {
-    "version": "2.1.0-1",
-    "container_hash": "9bd2760b48d637b2d49f23ca0b4f9abec0b539cf3326d10d30dd37be86bde255",
-    "git_hash": "61ed0979941b75bf0606e48b1cc56c6e8a803151"
-  },
-  {
-    "version": "2.1.0-1",
-    "container_hash": "ff8894b7834eeffc805e012df3e84799a0af95af7200b53d9cbecceb768c078e",
-    "git_hash": "a7152b0f136252a380c07f4a4557aa80e40107af"
-  },
-  {
     "version": "2.2.0",
     "container_hash": "20e1dec3bea4bea6d1ae56f945251a01cec610dac04b139f609183c96dc41fdc",
     "git_hash": "cee1ecf33ae2658997c525a23d1e4a96eccfebe2"
@@ -100,21 +20,6 @@
     "git_hash": "cee1ecf33ae2658997c525a23d1e4a96eccfebe2"
   },
   {
-    "version": "2.2.0-1",
-    "container_hash": "63d60dd2b5d9e26309c80504f8fe39bff1feaa2aa42c9d3efade73ada90f2b8d",
-    "git_hash": "ce5f16e5b755a0733d5c7a2b33782c0704030984"
-  },
-  {
-    "version": "2.2.0-1",
-    "container_hash": "ee555c0a5c4acbc96949d21f70e9793e1e1bb44d557c283f01b734ed185f72ec",
-    "git_hash": "c55a24b3e160279c0a5b8c96d786eb9686161f34"
-  },
-  {
-    "version": "2.2.0-1",
-    "container_hash": "eeabc1814f92937ee93b22e6c9b58f6a52bb21c72a15df151c989db884488fe2",
-    "git_hash": "c55a24b3e160279c0a5b8c96d786eb9686161f34"
-  },
-  {
     "version": "2.3.0",
     "container_hash": "08e69e566bbe588483ec0ac2a3cd2a32b0930bdc7129becbc8039dfb36c811d4",
     "git_hash": "262cad71bcda41795fd920c143b0eba4abfdf78c"
@@ -133,21 +38,6 @@
     "version": "2.3.0",
     "container_hash": "d35e88f806c17cad4d6d07ecf403009284a6d3094d28224e5a3ed3e4265e8616",
     "git_hash": "262cad71bcda41795fd920c143b0eba4abfdf78c"
-  },
-  {
-    "version": "2.3.0-1",
-    "container_hash": "14230e4d5e55fbacc9c64f4b9cbb3ba0192cdb2993b8522e4d8033c4c42374c9",
-    "git_hash": "61790b4bc6950a299c220ca591f3e1a8f1e3d3a2"
-  },
-  {
-    "version": "2.3.0-1",
-    "container_hash": "6fc47322e5ea5d968126aabb190787abd2ecd000e6f37d3e541a0ded181fd298",
-    "git_hash": "61790b4bc6950a299c220ca591f3e1a8f1e3d3a2"
-  },
-  {
-    "version": "2.3.0-1",
-    "container_hash": "ba2bb1f00fc170358a37894e63b792b65ed66b69466964d63861a6e49fc01764",
-    "git_hash": "fb1c097de2eca24288722d36fe24c315f0acc99d"
   },
   {
     "version": "3.0.0",
@@ -183,21 +73,6 @@
     "version": "3.0.0",
     "container_hash": "fb6d48397eeb29afdf6145691215395fe121d09b7f76dec367d39c211e5d79b7",
     "git_hash": "7331f051a110a5af6f5952b7d8d76e131fbb8f53"
-  },
-  {
-    "version": "3.0.0-1",
-    "container_hash": "2639e11f8dc18442ddf63daaff2bca251999c036b786ccb4d6172afff0683553",
-    "git_hash": "862f96ed9b8453eae9491607b5259365e2bb73d7"
-  },
-  {
-    "version": "3.0.0-1",
-    "container_hash": "73d07380b5b9087f01749c4aa865f957e8104481fcdf5abbd928c97f9649dfd5",
-    "git_hash": "862f96ed9b8453eae9491607b5259365e2bb73d7"
-  },
-  {
-    "version": "3.0.0-1",
-    "container_hash": "cd21cd4db856306c8d7c239d4dbf235d4f885f431d28d4cafdfd7551a6060c7a",
-    "git_hash": "5e25e2d7622a09666209843310eeb6f3149e143e"
   },
   {
     "version": "3.1.0",
@@ -460,316 +335,6 @@
     "git_hash": "1f280ac07e4bbec3708b8cb20d2bf301bb3e1ace"
   },
   {
-    "version": "3.3.2-pre.10",
-    "container_hash": "b9ee7b27b49e44eb06228ecd26f9cee9e6dad4e6312c51119f9a4b0b3f95eb90",
-    "git_hash": "09df2639107a9f5258a4549ff5e171e71f7f428a"
-  },
-  {
-    "version": "3.3.2-pre.11",
-    "container_hash": "cf1832f9ad310f30f080e558cacb9c9c65a156c5798c4d6d88600217108623ad",
-    "git_hash": "966c5e5c8b16afa71595006cf6ad86666a63ffb1"
-  },
-  {
-    "version": "3.3.2-pre.11",
-    "container_hash": "f08e91ff01b22e870a6131310868f36e0a90a398c844617519e29abef3147465",
-    "git_hash": "966c5e5c8b16afa71595006cf6ad86666a63ffb1"
-  },
-  {
-    "version": "3.3.2-pre.14",
-    "container_hash": "7fb988bfd043686dca5be0357caf42fcc11bf14e99cd97084506c249e17ce88f",
-    "git_hash": "d31b50eea8775ef86b383befa3ff9d7b73d926e5"
-  },
-  {
-    "version": "3.3.2-pre.15",
-    "container_hash": "0e67696d981559f637111805f61805192cdf4ec0e9834eb4f4d4c2e1e6e90279",
-    "git_hash": "dd61178b12d94d13ab13400bafea9d36504dccd7"
-  },
-  {
-    "version": "3.3.2-pre.15",
-    "container_hash": "119e04c404d6b915725b4f8b81ad0e4f1c978b4f24e8252d3afd0fbaaf278261",
-    "git_hash": "dd61178b12d94d13ab13400bafea9d36504dccd7"
-  },
-  {
-    "version": "3.3.2-pre.15",
-    "container_hash": "16090d0f2d6954de02c8b50a04c1679070df77ab4ff8b434b239a22f161479f2",
-    "git_hash": "dd61178b12d94d13ab13400bafea9d36504dccd7"
-  },
-  {
-    "version": "3.3.2-pre.15",
-    "container_hash": "17b07b72688ea55970e64712171b58e0ea56f9fc0d00c4b04e83e52ac1db0c0e",
-    "git_hash": "dd61178b12d94d13ab13400bafea9d36504dccd7"
-  },
-  {
-    "version": "3.3.2-pre.15",
-    "container_hash": "77dd2c5d140921a1c90e393d68d78fd34ca709a6e9e4cc3ed47031e2dc3abc80",
-    "git_hash": "dd61178b12d94d13ab13400bafea9d36504dccd7"
-  },
-  {
-    "version": "3.3.2-pre.15",
-    "container_hash": "9177b8776e2818bc4a99eef2af4060f822744b35da46833220020ed261f4a0fd",
-    "git_hash": "dd61178b12d94d13ab13400bafea9d36504dccd7"
-  },
-  {
-    "version": "3.3.2-pre.15",
-    "container_hash": "bb9b35c082af41b459246eb611f581e875a8751c43ee16fd86e2de88df39e0bc",
-    "git_hash": "dd61178b12d94d13ab13400bafea9d36504dccd7"
-  },
-  {
-    "version": "3.3.2-pre.15",
-    "container_hash": "d18155cb8adc69cf4fffea99e89284b085ddc148cf1ad19993b52733bbd34a1e",
-    "git_hash": "dd61178b12d94d13ab13400bafea9d36504dccd7"
-  },
-  {
-    "version": "3.3.2-pre.16",
-    "container_hash": "525623e1c0e01ad79b012d1572017ea776733d50cda4f8add4842a41a39191cf",
-    "git_hash": "785c1179ffc610f1f39a681639dd7bd9c33215e2"
-  },
-  {
-    "version": "3.3.2-pre.18",
-    "container_hash": "3e7a6adbdc82f8642e6c3f396db1125d7d0ca5b8edf9324bf6ea9fc71650f43a",
-    "git_hash": "2fa1927ad4afcdb03901f8a2a21b821e2ccfe9a3"
-  },
-  {
-    "version": "3.3.2-pre.18",
-    "container_hash": "cc665ac703665df142003946cafaa2762d79fca5fad32e4e5a12e58fe77dc991",
-    "git_hash": "2fa1927ad4afcdb03901f8a2a21b821e2ccfe9a3"
-  },
-  {
-    "version": "3.3.2-pre.19",
-    "container_hash": "6e1dec8c04ec65de61f0594c93291eb6dfc4a4817a877fb5d0f3f425405bd884",
-    "git_hash": "1363e72f157c32b230ebc4361d95924dfa1675bf"
-  },
-  {
-    "version": "3.3.2-pre.19",
-    "container_hash": "e78aebd918e7ea9850ebe8c0a38eb712839c9b2e4673a5d77f942611b59e9b4c",
-    "git_hash": "1363e72f157c32b230ebc4361d95924dfa1675bf"
-  },
-  {
-    "version": "3.3.2-pre.2",
-    "container_hash": "328601e37d7d7ee7cc061cd41efd188322b951ab7f56217e4193a4e0ede4324e",
-    "git_hash": "2a4a565b3f165c23bc320e53164559a1467b7c59"
-  },
-  {
-    "version": "3.3.2-pre.2",
-    "container_hash": "3378f559b63a870bf80848bb3cf1aa13a5e572b0547cdd5105bdb3b61b355e9e",
-    "git_hash": "d9c3254a37a4d94e4036cd95421e2fba40387ceb"
-  },
-  {
-    "version": "3.3.2-pre.21",
-    "container_hash": "b6279605a8a0f03cb26f190c5c4f0bd0770ab5dee8ea2b1444a2a64c66547663",
-    "git_hash": "509038a7edec55095e2796a92b136ad547f9e8c5"
-  },
-  {
-    "version": "3.3.2-pre.22",
-    "container_hash": "a626e1c74a02e62d93b753af8375f382690dbffb19df306befe9f843519d3cda",
-    "git_hash": "66b57046bda4e19984658468b455a8056a60a24d"
-  },
-  {
-    "version": "3.3.2-pre.25",
-    "container_hash": "a19ae1080cb9143083274156977c3a2b64a98bccd22b5af697166d522ca8430b",
-    "git_hash": "75f24a647c5be34ee3e48bdc7809f263368e98dd"
-  },
-  {
-    "version": "3.3.2-pre.25",
-    "container_hash": "e5fbef17d59dbe56726cd7f508175ef642e4784f7d9bb1cdffbdb8e9630f14dd",
-    "git_hash": "75f24a647c5be34ee3e48bdc7809f263368e98dd"
-  },
-  {
-    "version": "3.3.2-pre.26",
-    "container_hash": "1d75d8da7842a48080e508084195dd1ccac62f37531789da45d319a63a5379a5",
-    "git_hash": "e5e65fec68802b76745ae1f22df94173995470e0"
-  },
-  {
-    "version": "3.3.2-pre.26",
-    "container_hash": "3c4ea4b5d3d14ad6f7d6d248cec3513dd695dd9814e585948a20a75b5afd6305",
-    "git_hash": "e5e65fec68802b76745ae1f22df94173995470e0"
-  },
-  {
-    "version": "3.3.2-pre.26",
-    "container_hash": "3cc1cfc1c6fa2088423767f3bf2f4b4c759660922c5adf7bfcaaab6995937d89",
-    "git_hash": "e5e65fec68802b76745ae1f22df94173995470e0"
-  },
-  {
-    "version": "3.3.2-pre.27",
-    "container_hash": "6a6a70d510b74493fc7d72f3849c69c9f6e97a466874ca938b0999c6c9996dc7",
-    "git_hash": "5b958c5d329f1b086c0159216abba837f38f56c7"
-  },
-  {
-    "version": "3.3.2-pre.27",
-    "container_hash": "de9c4a628007e152eaa44d178df5ef04d7ed6effcc997ad9897ea63118720066",
-    "git_hash": "5b958c5d329f1b086c0159216abba837f38f56c7"
-  },
-  {
-    "version": "3.3.2-pre.28",
-    "container_hash": "9bf511f554db4b374b91272e99c7a80a7b437b3bc6f0ff5b65b7e2e98285ccc6",
-    "git_hash": "e950bfbd59f2ab8d667ceba235f0429f290ee48e"
-  },
-  {
-    "version": "3.3.2-pre.3",
-    "container_hash": "78c642803db03a2477d30320ab2fb903c9f9a53e8b68ad951a42e195f0dd5f73",
-    "git_hash": "e667f40f1d2d71173534722a16914fbbadb3f5dd"
-  },
-  {
-    "version": "3.3.2-pre.3",
-    "container_hash": "8d19b6c3e0d70504d5f7e0d3c63dc495d37190f011ae06b536cab760ce757d38",
-    "git_hash": "67a95cda76c0ea6ad978386f265db167c3174358"
-  },
-  {
-    "version": "3.3.2-pre.30",
-    "container_hash": "ddd6f2d3d38ba2783a6349e2bf9aeb3e15fb0976a8796dc7c49a6fa416bf8c71",
-    "git_hash": "bbd41d1712de8c18a101b2e2df1c5cc5c80c888e"
-  },
-  {
-    "version": "3.3.2-pre.31",
-    "container_hash": "056e690deef219a9b3606ec75a9d6d3261f6928aa0a4aad0d11ccf2cc4a06324",
-    "git_hash": "7f8f166e776d8c1ed8657d2ff127a3bc57e94ccd"
-  },
-  {
-    "version": "3.3.2-pre.31",
-    "container_hash": "1bbad8f2556c652cbcef688922689b84398b1c4546fef7f9969759db8a9d1d36",
-    "git_hash": "7f8f166e776d8c1ed8657d2ff127a3bc57e94ccd"
-  },
-  {
-    "version": "3.3.2-pre.31",
-    "container_hash": "efb44cabf9f15c8873daf9fe40c67795ad75f32ea102186b6bd220bc46e70347",
-    "git_hash": "7f8f166e776d8c1ed8657d2ff127a3bc57e94ccd"
-  },
-  {
-    "version": "3.3.2-pre.32",
-    "container_hash": "03d3ab0557b72a6bfb3f1ab80f04b6c20303596fb11fc59a77ef4461cbdcb3cb",
-    "git_hash": "33e11a35a3472203b9b048da54d191346e2c6fe6"
-  },
-  {
-    "version": "3.3.2-pre.32",
-    "container_hash": "1047d577245f27ecd13a3aa75360d7eaa90968e1398fc523ebc28d3f1f869438",
-    "git_hash": "33e11a35a3472203b9b048da54d191346e2c6fe6"
-  },
-  {
-    "version": "3.3.2-pre.32",
-    "container_hash": "2a166d9a2cef5d1e5b989d03a84ca044ef6847a6f1f398578d52ee12d812dfa7",
-    "git_hash": "33e11a35a3472203b9b048da54d191346e2c6fe6"
-  },
-  {
-    "version": "3.3.2-pre.32",
-    "container_hash": "43f8c47bd6caa9c1d5c4afb69e4ddf13506cd202824cbd9b76e722d6dfbe9146",
-    "git_hash": "ce20c8e78279f5f0da2bc4966b165c60033424b4"
-  },
-  {
-    "version": "3.3.2-pre.32",
-    "container_hash": "73f5a64472052ef24bc33049d57e3e726b1ffc3119513a1d0ecb51c24a9b30e0",
-    "git_hash": "33e11a35a3472203b9b048da54d191346e2c6fe6"
-  },
-  {
-    "version": "3.3.2-pre.32",
-    "container_hash": "a99cb461e30b1d03903f89c4e7a76e494393ec10ce8d4a7c56cd56619b95d652",
-    "git_hash": "33e11a35a3472203b9b048da54d191346e2c6fe6"
-  },
-  {
-    "version": "3.3.2-pre.32",
-    "container_hash": "dcd20f73f99ecb1511bc50732cd98b74b8635f5dc46f96667ea29a96d8db1cde",
-    "git_hash": "33e11a35a3472203b9b048da54d191346e2c6fe6"
-  },
-  {
-    "version": "3.3.2-pre.32",
-    "container_hash": "f7b02002a649f9c7e95fa24d771fae3a98fbcd00369062bfa41b4a2df1307f79",
-    "git_hash": "33e11a35a3472203b9b048da54d191346e2c6fe6"
-  },
-  {
-    "version": "3.3.2-pre.33",
-    "container_hash": "05eab0c82ae8c39c6cd8d16669d14c1ad0bf91d0d69a4720158967db414c0c10",
-    "git_hash": "d79faf4f4b0fe37451a9c300ddf1a549e3969cf0"
-  },
-  {
-    "version": "3.3.2-pre.33",
-    "container_hash": "1963dd54b29e0f1a93ba262979ba7f0e5bdb36c1dbee22cee679e1d71ec84d52",
-    "git_hash": "d79faf4f4b0fe37451a9c300ddf1a549e3969cf0"
-  },
-  {
-    "version": "3.3.2-pre.34",
-    "container_hash": "616665609146c84a3f90995e6b5ad3caae384c2bb2e4555c6e6727e447d46690",
-    "git_hash": "e09351ed39882cb2efe643c9d15502e0f51fe8d3"
-  },
-  {
-    "version": "3.3.2-pre.35",
-    "container_hash": "1f3c30fa45461f8dfeb1e3760dfe00f6f88c3b9549810ef2967e76f62ef68f94",
-    "git_hash": "abcbb0586809fa11eec33668a5d5159b73a31e42"
-  },
-  {
-    "version": "3.3.2-pre.35",
-    "container_hash": "6e76d88a24ed9813781d9685ad033f2f714eef352d1f76e97cb8a6c81425ff28",
-    "git_hash": "abcbb0586809fa11eec33668a5d5159b73a31e42"
-  },
-  {
-    "version": "3.3.2-pre.4",
-    "container_hash": "451440312582142d3588b23901366237bf192f71b743ae1aef2f966a2afdd221",
-    "git_hash": "031a7a70592945baea876867519d740a6cee13e2"
-  },
-  {
-    "version": "3.3.2-pre.4",
-    "container_hash": "ef0db1219054d0706ecc7822a340498525bdcc8733b47ce2943fc879ab326d96",
-    "git_hash": "031a7a70592945baea876867519d740a6cee13e2"
-  },
-  {
-    "version": "3.3.2-pre.4",
-    "container_hash": "fa92b55c67699e0d47a6fa66e51957c95b1b5d88b1bea215bd5bfa3e715b433a",
-    "git_hash": "4e23da8ddaaa4c1ea1e70c95e32683eda3074c7a"
-  },
-  {
-    "version": "3.3.2-pre.5",
-    "container_hash": "1df0f683234c01bdfbbc62d822246813b539516ae5f024c4fbedb72a0956c259",
-    "git_hash": "8e493820a767fcfb0b8a17617d91af56eba64473"
-  },
-  {
-    "version": "3.3.2-pre.5",
-    "container_hash": "3bd4f2eb908e92f8b6cc771f73302c92b4c6cff4ac355358d2b3c31c3ceccb05",
-    "git_hash": "850953a02e3dc5260ddc7b07d596ea5fd9aebbc2"
-  },
-  {
-    "version": "3.3.2-pre.5",
-    "container_hash": "6b2a803fd41ee578ab4b83a8dbe3433318412b63c87b75becb261778c891f411",
-    "git_hash": "5ab4d5bc30b4fd199dd10c408e7efb9ab92de609"
-  },
-  {
-    "version": "3.3.2-pre.5",
-    "container_hash": "8097f572e9b933c8889e5fb56da476f91790a02e15cfdb14b34153c31129af27",
-    "git_hash": "a39f556f8070e649d493ac6846e3ab9b78892c03"
-  },
-  {
-    "version": "3.3.2-pre.5",
-    "container_hash": "8ec7a4d49681405aaa2e4b364444cfde871a83ff6a6904a71dd674b4cc7427cc",
-    "git_hash": "d3b5dd22ed6adb395dd58f08460b7b60802c3ad1"
-  },
-  {
-    "version": "3.3.2-pre.5",
-    "container_hash": "a1f4432b8f2ec47e3d925a638c0744cb2c52322e5de7a89856fd63274d967dcb",
-    "git_hash": "d3b5dd22ed6adb395dd58f08460b7b60802c3ad1"
-  },
-  {
-    "version": "3.3.2-pre.5",
-    "container_hash": "b63996eac7c64328fc108a9489d5b744a4619ab86d4fdc5fb517eea9f80f6639",
-    "git_hash": "a87a93981d18ce5cb2b37dbbdb388c7790b97abf"
-  },
-  {
-    "version": "3.3.2-pre.6",
-    "container_hash": "d0b5ca8e965fadfe3dc34c743d912bd4fcdc52f35061c3d4f13d2697c8b50dac",
-    "git_hash": "dbe15a74226ab531a908903e686278c3ba474b7b"
-  },
-  {
-    "version": "3.3.2-pre.7",
-    "container_hash": "9634e804396f21164f6a73bcfd604f5977135880da6ecb4c36d6d4d7fb7a3259",
-    "git_hash": "7d0489e13f9ae2b7bd685916cec7c28251947d20"
-  },
-  {
-    "version": "3.3.2-pre.8",
-    "container_hash": "1020e334e739e133b46b6d7e40409dbbe62a089764acfee81d608317cec4329d",
-    "git_hash": "cd87b935f1596185136d82b330df115cd6058de6"
-  },
-  {
-    "version": "3.3.2-pre.9",
-    "container_hash": "f891a262f503d722fd24e1262b5884225e57d052569eeb1ed8ee77f5e2c1e0fb",
-    "git_hash": "2e02d0d45e2cadb0290bbf3e3840fa51b0f452dd"
-  },
-  {
     "version": "3.3.3",
     "container_hash": "1a14a7ec5af58198136c52068d503fa4e43e52432804cb0e30535d6f73cdabaa",
     "git_hash": "f3f1dde4aa7244adb813acf155bf5de196aa30cd"
@@ -810,21 +375,6 @@
     "git_hash": "f3f1dde4aa7244adb813acf155bf5de196aa30cd"
   },
   {
-    "version": "3.3.3-pre.1",
-    "container_hash": "43a945f0059966483cdb71dd340d67f0b8453bfd1fff0a7176df86a10abfa8e9",
-    "git_hash": "2f058041020d480b9433a24678ef376c0f740b1f"
-  },
-  {
-    "version": "3.3.3-pre.1",
-    "container_hash": "7157c86c63ec4043db6b690f85f482805da686c43e1e69d2f1916434c763919a",
-    "git_hash": "2f058041020d480b9433a24678ef376c0f740b1f"
-  },
-  {
-    "version": "3.3.3-pre.1",
-    "container_hash": "9e97cf4758783847a2669d5643608efc9c85c79566b203152c4e5374754ac877",
-    "git_hash": "2f058041020d480b9433a24678ef376c0f740b1f"
-  },
-  {
     "version": "3.3.4",
     "container_hash": "26040a1801f3aa8b45c9c3e6483c8c19f6c7468c671b5a1b9367b8523fb5b43c",
     "git_hash": "53515458fabdc9510830dc71fbdd21082f0dedd5"
@@ -863,21 +413,6 @@
     "version": "3.3.4",
     "container_hash": "f631e0ac8e9aca0ea241747d45a2a44b68311ab1b45ac8266ec8eced40d202fa",
     "git_hash": "53515458fabdc9510830dc71fbdd21082f0dedd5"
-  },
-  {
-    "version": "3.3.4-pre.1",
-    "container_hash": "1f1a3472625d98740c0a5e872f1e7b4408be848dab4874e055b63f9b6fa25746",
-    "git_hash": "04079f1c4b7fcbcfec56e354967be9ceda50a613"
-  },
-  {
-    "version": "3.3.4-pre.1",
-    "container_hash": "4b58d969804f08083f70e75fd3c620d0765e793c128cf3950577ac235b343fb9",
-    "git_hash": "04079f1c4b7fcbcfec56e354967be9ceda50a613"
-  },
-  {
-    "version": "3.3.4-pre.1",
-    "container_hash": "cb9704fd85ff0bf6400b6477478560150212392686805791be0d144fe0f8443b",
-    "git_hash": "04079f1c4b7fcbcfec56e354967be9ceda50a613"
   },
   {
     "version": "3.3.5",
@@ -925,21 +460,6 @@
     "git_hash": "f7a5fac7656f22525f7d17b624a0920cb41cf48c"
   },
   {
-    "version": "3.3.5-pre.5",
-    "container_hash": "56012ff916d038684d43ef789acdb7f05c088371feca31bdb3a19c199ba5ea88",
-    "git_hash": "e3a1cba9bc6a97e339636822e0bb177ac6ff5f61"
-  },
-  {
-    "version": "3.3.5-pre.6",
-    "container_hash": "481d15ee91443142c60c2a378db79c8b9e7e840dcd50cd322a169f50e3df870d",
-    "git_hash": "5c4ce6ccc6e647bcb9f7f130ef75d26c7f545348"
-  },
-  {
-    "version": "3.3.5-pre.7",
-    "container_hash": "6ec1db35c6ec53f41594d9e3044dfb642e278e69999f212552026baa542ff0f0",
-    "git_hash": "03a0b24960546ad6c0e58f09e791fe458b25362e"
-  },
-  {
     "version": "3.3.6",
     "container_hash": "04031e9875fd4e1bcfac162121a79df4b908d474bb9adf28812c9884691e2b9f",
     "git_hash": "0779e27ab7c8ab2e3b677a472c1f6823e95f3453"
@@ -980,171 +500,6 @@
     "git_hash": "0779e27ab7c8ab2e3b677a472c1f6823e95f3453"
   },
   {
-    "version": "3.3.6-pre.1",
-    "container_hash": "c4b037bd4a21075c20fb4d4d26ed6a316da10eb6d32e4d9e14806f0fb683504e",
-    "git_hash": "859d89a6f8ffb6e67f6dda46914e365dd3db3733"
-  },
-  {
-    "version": "3.3.6-pre.10",
-    "container_hash": "116106af5f673913310c277ff8335912850d6cfcc78d1734c5d3491fb06a1053",
-    "git_hash": "beae90fd0a4f40c8be6314fb487859374176e9f0"
-  },
-  {
-    "version": "3.3.6-pre.10",
-    "container_hash": "22093c902adf6dc131cdfcc096f7a417eb0363f4526a9af361250ebfc288e810",
-    "git_hash": "beae90fd0a4f40c8be6314fb487859374176e9f0"
-  },
-  {
-    "version": "3.3.6-pre.10",
-    "container_hash": "89eae1ebc0f6992f98f1997fb88dca1e28752b6633226a54fc683c3777c41c6f",
-    "git_hash": "beae90fd0a4f40c8be6314fb487859374176e9f0"
-  },
-  {
-    "version": "3.3.6-pre.10",
-    "container_hash": "b22fae30f062f02bdcb59d88099a6227b9d7f36992fca074e7339f2c3c4e4225",
-    "git_hash": "beae90fd0a4f40c8be6314fb487859374176e9f0"
-  },
-  {
-    "version": "3.3.6-pre.11",
-    "container_hash": "f16954c0ef86807232f51648e7c0d3670bba87c41f1796fbee1473c8b4657b10",
-    "git_hash": "a4cdf22aa9b7631a076b484f916b18336fb0c782"
-  },
-  {
-    "version": "3.3.6-pre.12",
-    "container_hash": "51721f95a95f6ec7c7d482d42277596d4974fc744ad32812f755aa7c62687a5c",
-    "git_hash": "5326e37dafe9670840a1333247c766f05f17e596"
-  },
-  {
-    "version": "3.3.6-pre.12",
-    "container_hash": "9514872c41e9ce6d2cee7027c96967b8790e59ef4ae8d8b0bfe5dac3fd9878de",
-    "git_hash": "5326e37dafe9670840a1333247c766f05f17e596"
-  },
-  {
-    "version": "3.3.6-pre.12",
-    "container_hash": "98f6cdc49596b2e1fe9b763de0eb96f1a8e19d4a7bbc6b4c5d784f37ae9b2439",
-    "git_hash": "5326e37dafe9670840a1333247c766f05f17e596"
-  },
-  {
-    "version": "3.3.6-pre.12",
-    "container_hash": "b518d61e9bce2994036fad06dce162407aedc60d63355fb308f2d05b18a8510c",
-    "git_hash": "5326e37dafe9670840a1333247c766f05f17e596"
-  },
-  {
-    "version": "3.3.6-pre.12",
-    "container_hash": "ba2731c95866b3da3724abda6bf25f6e4c102be8df3a46f0ee266255bbd9869f",
-    "git_hash": "5326e37dafe9670840a1333247c766f05f17e596"
-  },
-  {
-    "version": "3.3.6-pre.12",
-    "container_hash": "e516d3a2d01182e0c1a9866bbc757b1d517e1f4734e0313b600b066cd7ff7667",
-    "git_hash": "5326e37dafe9670840a1333247c766f05f17e596"
-  },
-  {
-    "version": "3.3.6-pre.14",
-    "container_hash": "2984a306be5530d9bc8a005d2b3366e0b81b170ef9c2662adc4b8a46f7b1ca6a",
-    "git_hash": "954c04af897ad71653aa003e7e3171839ca9298f"
-  },
-  {
-    "version": "3.3.6-pre.3",
-    "container_hash": "045fbeb912bf4569e14d8b6a9ddb7d43e769aa6f4d86535877aa8bdc1313b544",
-    "git_hash": "2fef6ceb4c9490601b4aab7437de3ab788845e4f"
-  },
-  {
-    "version": "3.3.6-pre.3",
-    "container_hash": "1499ac04c009e176401f0170745dbd13e6d75e80f9b3df81c8df570b83a23066",
-    "git_hash": "2fef6ceb4c9490601b4aab7437de3ab788845e4f"
-  },
-  {
-    "version": "3.3.6-pre.3",
-    "container_hash": "2ceca3b98619443b36c8de448bdfc55fa91dc688c646add58bf60b10e51e217d",
-    "git_hash": "2fef6ceb4c9490601b4aab7437de3ab788845e4f"
-  },
-  {
-    "version": "3.3.6-pre.3",
-    "container_hash": "814bb480d1bc12f935b6c240625eb9241a1e134bb8a690829f6f974c3af04f5b",
-    "git_hash": "2fef6ceb4c9490601b4aab7437de3ab788845e4f"
-  },
-  {
-    "version": "3.3.6-pre.4",
-    "container_hash": "1462422b2133e0db8abdf5beaaad0d717ff6c4a6711810d330f3657bcb7cfd5f",
-    "git_hash": "6f53b5ce1afac9976cb75d4920085441e42a0091"
-  },
-  {
-    "version": "3.3.6-pre.4",
-    "container_hash": "1dc77ec81cef2b27687ebd0f1d814aee402e2c866f2415c24d0cca2609f62e0e",
-    "git_hash": "6f53b5ce1afac9976cb75d4920085441e42a0091"
-  },
-  {
-    "version": "3.3.6-pre.4",
-    "container_hash": "49931b126de730ecfe4994ba7f3f725260cd82bb71dc8da0c12228f5c4db2aba",
-    "git_hash": "6f53b5ce1afac9976cb75d4920085441e42a0091"
-  },
-  {
-    "version": "3.3.6-pre.4",
-    "container_hash": "b8c6b138913edffb395e3feb76e82a705cdb8261c91e0f416ba02f90ec7a92ed",
-    "git_hash": "6f53b5ce1afac9976cb75d4920085441e42a0091"
-  },
-  {
-    "version": "3.3.6-pre.5",
-    "container_hash": "483500f1188e34e31730a456591fe82b0e2e4c49b5e0b840b5c9352fc4767ee9",
-    "git_hash": "cafc48df543415cb3d76387e91a8b20c2a40df01"
-  },
-  {
-    "version": "3.3.6-pre.5",
-    "container_hash": "be5510723759434bf295f5571e66f8ac9cd43d58ebbba3126653e4529cd02a38",
-    "git_hash": "cafc48df543415cb3d76387e91a8b20c2a40df01"
-  },
-  {
-    "version": "3.3.6-pre.5",
-    "container_hash": "f4331b2b5a37f2a390608a0b1caee1d60ae802216cd4388f687e54e62963c123",
-    "git_hash": "cafc48df543415cb3d76387e91a8b20c2a40df01"
-  },
-  {
-    "version": "3.3.6-pre.8",
-    "container_hash": "03ec6aa265d24caedcce2b51a83bc632a172537dbf20a368303f7e767182f466",
-    "git_hash": "e5c1b843536149b4369646ee9963177894fa9036"
-  },
-  {
-    "version": "3.3.6-pre.9",
-    "container_hash": "11e78ece0c18506adfbfccd535bc1c142c0abcf1205c03f12d56d33848ea770e",
-    "git_hash": "90861681a5a0be00b0a659e1e1905b8cd2160e31"
-  },
-  {
-    "version": "3.3.6-pre.9",
-    "container_hash": "2f494666c263d1fafbf971511bf9af94be0451ac8c8009ba4b72fb85ce2614ee",
-    "git_hash": "90861681a5a0be00b0a659e1e1905b8cd2160e31"
-  },
-  {
-    "version": "3.3.7-pre.1",
-    "container_hash": "3d2c4f221596accbb1cbcbfeca929d4219594af9642bb53009fa35fd82bf1387",
-    "git_hash": "e8114bcf892bd886bba5e1f17f6aa479a0fefbfb"
-  },
-  {
-    "version": "3.3.7-pre.1",
-    "container_hash": "921f38e33bef5be37b37e53e558cbc5a6329616f31b7334cc81ef706fa22deed",
-    "git_hash": "e8114bcf892bd886bba5e1f17f6aa479a0fefbfb"
-  },
-  {
-    "version": "3.3.7-pre.2",
-    "container_hash": "70f68d0e672e537519a6fd71f53b13c89d3b0787d31117ca231b0b0ca8068809",
-    "git_hash": "b0ab1e4878fb969cc1fd8fe7af992dc10c70f7fe"
-  },
-  {
-    "version": "3.3.7-pre.3",
-    "container_hash": "3cfec760e4112f93b64440abd4e0b1c4d3fb21a1129e6d45b713ad5d0be28bd5",
-    "git_hash": "4f3174dd2988ef58a31a408e8cc37c2b7bc1201e"
-  },
-  {
-    "version": "3.3.7-pre.3",
-    "container_hash": "67c8cc8e0a9b64d1741ad7cca325e8b74a7224225aa231f39fb82b2596e54689",
-    "git_hash": "4f3174dd2988ef58a31a408e8cc37c2b7bc1201e"
-  },
-  {
-    "version": "3.3.7-pre.4",
-    "container_hash": "0474fc80bd1a47b3cf866217abc16161dfb5d0a91450101bca7065df67d9a4f5",
-    "git_hash": "af38726146ee4546ba564ea3240aa0b584c88188"
-  },
-  {
     "version": "4.0.0",
     "container_hash": "0b482a546320710ed60b83aedeedb9b865e0969d1741936623cbac5346d2da8a",
     "git_hash": "1308fa6ae9091e5710bd88a59902de7b64af8897"
@@ -1180,106 +535,6 @@
     "git_hash": "1308fa6ae9091e5710bd88a59902de7b64af8897"
   },
   {
-    "version": "4.0.0-pre.0",
-    "container_hash": "625c25622a9b289347cd4e5fa944a189a6102b3a5a6aeda12cae025ee788209b",
-    "git_hash": "36ffb20f41abc57a864bd8aa0dfdd2e3c429afb5"
-  },
-  {
-    "version": "4.0.0-pre.0",
-    "container_hash": "b831fd1727ff9cfdd965ab89f4e20db05b87c52ee818d5dfbfb08d527211e5bf",
-    "git_hash": "36ffb20f41abc57a864bd8aa0dfdd2e3c429afb5"
-  },
-  {
-    "version": "4.0.0-pre.1",
-    "container_hash": "eaf01d50d07c8caa2b291cb4434bcaec1b4b86652c9be8fcacfd85cf16b0579b",
-    "git_hash": "86023da5959b58b901058b8aba9d9f02e1e5c919"
-  },
-  {
-    "version": "4.0.0-pre.10",
-    "container_hash": "9739ed28237dfa1763fd33e6ece82cb40f67267b4b79f877b80405ba7dcb5604",
-    "git_hash": "b4c7d099d62ecb187dbb0e20964e04db2f6d5cf9"
-  },
-  {
-    "version": "4.0.0-pre.11",
-    "container_hash": "71235f4d0b48f1099b9a2a9b67f3d6235e76e327860ac49c796cabd7612539ef",
-    "git_hash": "f86389d1b2419073424cf81d165d3be23434679e"
-  },
-  {
-    "version": "4.0.0-pre.12",
-    "container_hash": "a7e8bfb7808c0aa40ae7ec4f4ae9c8e8e49dca29a441229e179b2a86c0ff002b",
-    "git_hash": "d7905dbaae27a5a7abbd3b2e36c97aa8dd0cd709"
-  },
-  {
-    "version": "4.0.0-pre.13",
-    "container_hash": "eef1453183311199ded392ee4998e8990f6158e2410d29f8ab6936c4024a05c1",
-    "git_hash": "79a43388353bd930ca06600707394b6fb743b77a"
-  },
-  {
-    "version": "4.0.0-pre.14",
-    "container_hash": "bf253a8713b43f164fec147bfcdd96173c6d97f8cc6ad81a8fd6e0a2b6eb7132",
-    "git_hash": "3f1136c71bd3941b1571d2456552da531e07252f"
-  },
-  {
-    "version": "4.0.0-pre.15",
-    "container_hash": "38e98d50ee3224da1e40b47fb17c40e5880d80376d81c585af41a9101833d7ed",
-    "git_hash": "2aca041d48f32389ca80dc76ff15f264497095d1"
-  },
-  {
-    "version": "4.0.0-pre.16",
-    "container_hash": "ac23c02f97a3257939dc698bb21c217058001f9bf43bbc3f6db1b6f6b012457e",
-    "git_hash": "c31c8a63ef2dd38bfa776e92a5d74fa5e37c53c8"
-  },
-  {
-    "version": "4.0.0-pre.17",
-    "container_hash": "22adff47f865b05bd2122db03361a17f811f563928d311821d9a2ce2e21d3849",
-    "git_hash": "18469ccb03d0200d908d1677f8649258c11f0c21"
-  },
-  {
-    "version": "4.0.0-pre.18",
-    "container_hash": "9db7f338a356a7836b2e736f2f5ca8dda3ea094c8e87daf1c1f496879bc51e91",
-    "git_hash": "7895216d46ea86cf9025d3c1a48c6921ae08e6d1"
-  },
-  {
-    "version": "4.0.0-pre.2",
-    "container_hash": "a28d530381004a16e6db49b7e08e78b6f82015281e57d82c5f820ad5fc8b4d9a",
-    "git_hash": "4b980941c58f7269b3447426ba1dc8ff02775e7c"
-  },
-  {
-    "version": "4.0.0-pre.3",
-    "container_hash": "efb6bebf74839e8b7fdcaf0a6122fadd0f169caf79fadf114b4d40706eadcd7a",
-    "git_hash": "f07aa677425865cce1edb42f3b2952f7948650ac"
-  },
-  {
-    "version": "4.0.0-pre.4",
-    "container_hash": "9892164affba0f2b85218f204605761d96a2e236b6ac08eb230e1d9378668aa6",
-    "git_hash": "ef2a0aadd21cfc277b7f4c8bebeb458cebb957d2"
-  },
-  {
-    "version": "4.0.0-pre.5",
-    "container_hash": "8e11c02b4927ec52e97fd44732cffc625e6e76199a9f2029caacae3d1ffbcbcd",
-    "git_hash": "ffad10f8a0120529700bf1e58da8156778b9bf36"
-  },
-  {
-    "version": "4.0.0-pre.6",
-    "container_hash": "dca03239183892a3c4d9882a211d5acecbb32d0a74919e45382b663926895fa6",
-    "git_hash": "466cced0d9ed1d31929b172e256c56fe5e918887"
-  },
-  {
-    "version": "4.0.0-pre.7",
-    "container_hash": "dc08034234446f5edea1fce713a424e407843af2f6726817a2c6ade89f2834ae",
-    "git_hash": "687ce76f4136d204d26c01742d45e762eae99ebb"
-  },
-  {
-    "version": "4.0.0-pre.8",
-    "container_hash": "bee53accb4cde90dbf23e2c376a2f5db84f7053a00ff0118e37de71d1210397d",
-    "git_hash": "7146994d2872a28a4e31c7ce4c8175904ddb8b75"
-  },
-  {
-    "version": "4.0.0-pre.9",
-    "container_hash": "38bf1185862927abaadc1ddb97b983bdd7628b427ad9e83fae81455829e5769e",
-    "git_hash": "7fe61c758e17d69689cf1a431dcb8c29bc82bd0c"
-  },
-  {
     "version": "4.0.1",
     "container_hash": "251432facad8df93c36f0c7d8b9594718520eded6422fcaeec07fec1aecce94b",
     "git_hash": "441c4e7ba9ecb46c0d95701afb3fec64b76aab27"
@@ -1298,231 +553,6 @@
     "version": "4.0.1",
     "container_hash": "be5ca6bb5f74f0916b18539e79b30c9109396a34683f3125d147101ed2365ff2",
     "git_hash": "c1f792bde2910d75714125271404933b8322d6f1"
-  },
-  {
-    "version": "4.0.1-pre.10",
-    "container_hash": "2164d4499236fbb190bfd2e5005571c6bdb687607a0b464c8c4a5b47beb0af76",
-    "git_hash": "f06c808201005cf1813089cb17dfcb6fd514e88b"
-  },
-  {
-    "version": "4.0.1-pre.11",
-    "container_hash": "b9ae8ead8f7aaeaa401f72ce25ca15ff026b3fe71dbe4c17efe788260779120a",
-    "git_hash": "b0bc2fd97b1459acb54225490fe50b57d11de316"
-  },
-  {
-    "version": "4.0.1-pre.12",
-    "container_hash": "0ede4bf2c06798e0b0d60a5ee61146e9c6c91d67a2653f6223f8244bdb6eb128",
-    "git_hash": "5ec9933bca9fc71648f87c5777e85e00be22d22e"
-  },
-  {
-    "version": "4.0.1-pre.13",
-    "container_hash": "4c6285711baa0301c0e56b4c1ea1771cc886a0146031f42fa5910051bd0c4965",
-    "git_hash": "2c3de7d4f1d61394015de9e45b34fc53d9fa2854"
-  },
-  {
-    "version": "4.0.1-pre.14",
-    "container_hash": "aaf8d49940062ab0e37943d0a7138b49029401a2f2eff98f5458354bd54e38de",
-    "git_hash": "ea167fae7e425dceb2e87e9f3cd410c7a53427de"
-  },
-  {
-    "version": "4.0.1-pre.15",
-    "container_hash": "ca6547d681b8ee90db32878a371a5d09fc516f50684928f13ba4190266f4324b",
-    "git_hash": "1f1fbbd2474b132cc1d3406d1865911d7d9f5202"
-  },
-  {
-    "version": "4.0.1-pre.16",
-    "container_hash": "3c6476a521705dc0e0e3db13c4698a6a0e4c451129330303f14235f1c0666f59",
-    "git_hash": "c65120f813eeac69895ff2ddb0c820b0b512aa0e"
-  },
-  {
-    "version": "4.0.1-pre.17",
-    "container_hash": "93720642cc279bb1c7f5f924cdc2c6a9ddfe7ff0eb40ec29e177d6ca7ce7cfaf",
-    "git_hash": "45ad87b1344f4766796543d81adbf72e30c4e75e"
-  },
-  {
-    "version": "4.0.1-pre.18",
-    "container_hash": "21892972412f9005dc386b0fcbb8f533e478edaa3d64e78e4fb687a27a3f566e",
-    "git_hash": "f57cb58c5b4a7bef865c9b5b34810f5390d517aa"
-  },
-  {
-    "version": "4.0.1-pre.19",
-    "container_hash": "751deb72a771dbbdcb43f24ef5a0c2569a1f1b2dc48e628739424dcd333141a5",
-    "git_hash": "225f7cb0ca9bf9ea85284b9fa8763f102076351e"
-  },
-  {
-    "version": "4.0.1-pre.2",
-    "container_hash": "9722bce0bf1c277bd2fb6c86160a6bd7cb0a3ff93e828309d7e146e7e4aa6bbf",
-    "git_hash": "e9d75fca6f3aacdd13abfb9f551e3877915a9440"
-  },
-  {
-    "version": "4.0.1-pre.20",
-    "container_hash": "cf4626ef55f224c1b1f3923d88eb041ea85ef0d0c7abcec54a32fd168eb37155",
-    "git_hash": "c4263cea14125db1dece1434ae45e13263a97d94"
-  },
-  {
-    "version": "4.0.1-pre.21",
-    "container_hash": "d04df964884c2561adf547057e32e36e2111a4b1daaffbcfb75c468226c5d2ba",
-    "git_hash": "ab04f636ac210150798300fbaf8ebb6b2faaf61f"
-  },
-  {
-    "version": "4.0.1-pre.22",
-    "container_hash": "9209ca13a56a81905d979dd865c7e9a311642aa2854c9e797d5dfa30eb0bfe05",
-    "git_hash": "fc19d2cdc7149ac263b15084917c28e78878f228"
-  },
-  {
-    "version": "4.0.1-pre.23",
-    "container_hash": "fd2de12f78a3cdef8526bb32f37db9affe0c6f685b086fa91a9fd9ee8951dff5",
-    "git_hash": "bb9b0b9354d23fe4285d6099e47b4b7f3813a143"
-  },
-  {
-    "version": "4.0.1-pre.24",
-    "container_hash": "8f2f11fd3dda6654fc25b17042cea657dcb04f2c6ce43011d2e47c4b253fab81",
-    "git_hash": "6fdcb5deaae9bf3450758566ab9975b8c8e4b67b"
-  },
-  {
-    "version": "4.0.1-pre.25",
-    "container_hash": "86adc3330132839a3d13b76d8b4b75a9f8354b4db78e7337cacfeb8242a482cd",
-    "git_hash": "7057c55a587f0e9c1e6435b4691ab4d939f0c2eb"
-  },
-  {
-    "version": "4.0.1-pre.26",
-    "container_hash": "2e8f5e53bfb9c5fb90f3271bfe1eac62d4c88d05f1dfcf7b89f66453dacbe485",
-    "git_hash": "ac603c54d258062ddfc11772ebc96e44ad3f20e1"
-  },
-  {
-    "version": "4.0.1-pre.27",
-    "container_hash": "50ad169bb4be64eec71a259e47d2421b879a0469201788206a375e26458a9ea7",
-    "git_hash": "d47fb7550728b4a9e3805494ad9d28d1765952ea"
-  },
-  {
-    "version": "4.0.1-pre.28",
-    "container_hash": "17c79d97ae7984951d5327e8340f277c0927ff37f89a44ecbbed77c79dca809d",
-    "git_hash": "224a7c601d0d9ff1cb1358ac19f9835f1f3c35fa"
-  },
-  {
-    "version": "4.0.1-pre.29",
-    "container_hash": "c6868d09be41667f7af907516e3c03996abfbd00e9d188e0aa323dcd861948f4",
-    "git_hash": "c29c4f58d94f7910a25b1be6a83f3e14112ef070"
-  },
-  {
-    "version": "4.0.1-pre.3",
-    "container_hash": "2ac137ba41d181e6189cd90032eab0f3c228205e4ef7666ae1e9638a799aec80",
-    "git_hash": "6a6e93a4e645fc565bd9e8c32700f92cf2637745"
-  },
-  {
-    "version": "4.0.1-pre.30",
-    "container_hash": "fe72f6a350b0dea8d0e7f9024b0d5a102a7ceb088239dadfec1fcc9cf70170fa",
-    "git_hash": "0b2ec17e22152c256a2b773854535f15bd195475"
-  },
-  {
-    "version": "4.0.1-pre.31",
-    "container_hash": "c146ce879ee507d6e3eef408f4eb466ef85238509ad22f1b786883b642b89c52",
-    "git_hash": "056b003ad8b2cecbe32a80d62b923019da8d9cf4"
-  },
-  {
-    "version": "4.0.1-pre.32",
-    "container_hash": "66d61a1771d784559648c99d08f4f0539b1ca346e497b3d34cf5faa46ec7b584",
-    "git_hash": "ab9ddc476fd413a349b10a41b534a12aea5df1b9"
-  },
-  {
-    "version": "4.0.1-pre.33",
-    "container_hash": "c9af453fda119279e72de181550b73b1f2dec8fc75e9a7582cc90369149523c7",
-    "git_hash": "a30b945d07f19db9267d6197745878e616e54e3f"
-  },
-  {
-    "version": "4.0.1-pre.34",
-    "container_hash": "c405ab4c2c8d9df2527522aeeac126b708006febd7c941c70e2d7f1e6d442285",
-    "git_hash": "8276803a57b3b1959403130c1a6771e75fcfdf11"
-  },
-  {
-    "version": "4.0.1-pre.35",
-    "container_hash": "b23013240e017464e20bba3f43038cecffde371e0a49003ab09eb6113b6b7a60",
-    "git_hash": "6eadb00d77a9792be7a9ba59de79be2fc59a5eef"
-  },
-  {
-    "version": "4.0.1-pre.36",
-    "container_hash": "ad75020fa98e018b6ddd810b24607e858da867b1f05a11950dc624dd0932f846",
-    "git_hash": "a44355fcc893d4489bc89f455492c5469ba1eb4e"
-  },
-  {
-    "version": "4.0.1-pre.37",
-    "container_hash": "980dae190acfd6972983d89404e293269dbaa0ec57d4542ebe1d9795e05e2d0a",
-    "git_hash": "1e0038007d713939113954fd92ee3bf6ee0b189b"
-  },
-  {
-    "version": "4.0.1-pre.38",
-    "container_hash": "d162f1bad1199db4025f693aa66a3ccab78ef7f9e4443bb36d18c5bbce455a75",
-    "git_hash": "37a525ad1592ab093f7b3cd4b809276eb5d20357"
-  },
-  {
-    "version": "4.0.1-pre.39",
-    "container_hash": "c85f57ea4182857896352c269f19c3d6c843a0a9ec80b01c1006bb45291aebd3",
-    "git_hash": "4ab90edbc8611f62853058b0ba738cc9ce885464"
-  },
-  {
-    "version": "4.0.1-pre.4",
-    "container_hash": "a0943157be04954f2a1ac5a28957f40665338de296fbad856b7e8ad2c1345dc2",
-    "git_hash": "634538693f097a64a29dd6a342cf8b941126ddbe"
-  },
-  {
-    "version": "4.0.1-pre.5",
-    "container_hash": "49473ce3f70af21e15e515280b088b85a4011825e7f3cb0156746c34cbe4cecf",
-    "git_hash": "d3fe7be43d30241b414ac925e78e171f99329603"
-  },
-  {
-    "version": "4.0.1-pre.6",
-    "container_hash": "38c96a022818995230fb02ede45d24b4f34fa5c89711ea24002e478df61e275f",
-    "git_hash": "f930fe567957f162a27f29e2d53f79920b286249"
-  },
-  {
-    "version": "4.0.1-pre.7",
-    "container_hash": "a9ee6129d8bb1c6681fc0d52e636e4f7418cb9d469f6b3ea2b7330488f105867",
-    "git_hash": "f7d8c89fe065de48898ea464e0f918ec20f9ac3d"
-  },
-  {
-    "version": "4.0.1-pre.8",
-    "container_hash": "edd7da9d759556abd09e1c1e45bdd3389a646cc117473323db5c9c53301cac73",
-    "git_hash": "70012037946291d2cf01c24404395e2642d60c2a"
-  },
-  {
-    "version": "4.0.1-pre.9",
-    "container_hash": "075192dc5ec8a384549670c3b1e7c16e0099051dcbb3cfd77ea966e71a0ac136",
-    "git_hash": "6e94d5600d034d4e70bc4795a241065eaf358204"
-  },
-  {
-    "version": "4.0.1-rc.39",
-    "container_hash": "842181628472a2c086d15aafe42d82fdd56ac44ad235ef75e18001e245fd33b0",
-    "git_hash": "0be71b756d36d080d21e723323ae4fc51148df63"
-  },
-  {
-    "version": "4.0.1-rc.40",
-    "container_hash": "d1f4028fa112b48d78405dd45f83a61c2d1552ba29f7b462d946eab6316573fc",
-    "git_hash": "5fbd60041864cb1d5707ac1e9019d869ac94cf50"
-  },
-  {
-    "version": "4.0.1-rc.41",
-    "container_hash": "9616d58e7874ad3fc953794343008d77d2924d8e6dedee8f63196ec4d2df51e7",
-    "git_hash": "686f423dfc025088c2b75c697b9f0c0e27d3a642"
-  },
-  {
-    "version": "4.0.1-rc.42",
-    "container_hash": "43fe2ba7335bd3cf26305700a4908b6c8cacf0df3d1f684e02b64e14cc7d6867",
-    "git_hash": "8de43243de82b0aa3c3a73c659104ff745080d18"
-  },
-  {
-    "version": "4.0.1-rc.43",
-    "container_hash": "ba99dda5d62aa03f2209e5301caaf7f8225e5c30f7cb1531325b56e27bb4b6b9",
-    "git_hash": "22c4066ba6d5bd001f39b31273540fd4ce2f080d"
-  },
-  {
-    "version": "4.0.1-rc.44",
-    "container_hash": "b1704a8cb5b59e20f390c731a3f8532e9e95dc7bf36969726e5f151ee2b17707",
-    "git_hash": "4256a955338454e86add15ceaa109bdde97f8dfd"
-  },
-  {
-    "version": "4.0.1-rc.45",
-    "container_hash": "1f35693a8ab74f17bc36233b6b8cce4ac1d83b303726197c9825be0945f00228",
-    "git_hash": "27b3f6c9c3cc66ffe5e5bbf2d8480c3fd316ff9c"
   },
   {
     "version": "4.1.0",
@@ -1556,56 +586,6 @@
     "git_hash": "4e07a7cb5ac6b670cc09953d937011a91bcc34be"
   },
   {
-    "version": "4.1.1-rc.0",
-    "container_hash": "36bd3765a8e14828b950427e23246797d3e1b43bca3b0ed01fe96c4e523fb0f9",
-    "git_hash": "2bed68fde455a2d6cbf392e6a3323894c879c609"
-  },
-  {
-    "version": "4.1.1-rc.1",
-    "container_hash": "40f6c297baff3c46b4c8762cf5efeca08558457bdaf552bc4f5e35e0da313ff6",
-    "git_hash": "63abf36c165216cc128492eecea2d37e172a13de"
-  },
-  {
-    "version": "4.1.1-rc.2",
-    "container_hash": "44ba1254e02f6e45a25d796a7e1ec63315c442d392138c78a0505c3a96578c8b",
-    "git_hash": "ddcd70268a9df56542a4217a9f9437e8a420d31c"
-  },
-  {
-    "version": "4.1.1-rc.3",
-    "container_hash": "4f87415756f09564ebe5fcdfa190c3a659ae98eefc869ef9b0e245a3b5d9d308",
-    "git_hash": "436080f13a3dc700d43ab5f20e126b59dcbb851e"
-  },
-  {
-    "version": "4.1.1-rc.4",
-    "container_hash": "a0f18483774b25022461cab2586fb93a29572f7bed8b4092a17ac4946bd847f0",
-    "git_hash": "3b313db06f97aa34c7cede5ef15e330825172be6"
-  },
-  {
-    "version": "4.1.1-rc.5",
-    "container_hash": "327f6dabf29c67309386cd4dbd63afe974b011b7c60e53a660da5e5c19202097",
-    "git_hash": "609de02683eaaff3c913d9f46bf202680946a58a"
-  },
-  {
-    "version": "4.1.1-rc.6",
-    "container_hash": "6b797762df3efca56972b168584cb61696e1eb9a95cbcef0a50fdfdda62d8256",
-    "git_hash": "c08c3aa4cb4e06f3473fe882047099979f2a6b94"
-  },
-  {
-    "version": "4.1.1-rc.7",
-    "container_hash": "7a7c6787f839808e606fd93cec11c68341925e650dcffeef922a43ba14a5dfe8",
-    "git_hash": "cebe7edc95eedd0334b4626394bf4fdf788a32fd"
-  },
-  {
-    "version": "4.1.1-rc.8",
-    "container_hash": "7a1f080bf55f8d6e73ddb4773697843f44b30e648d565c952ff7ef623e1cecc1",
-    "git_hash": "d8da82a8673ee2ac08dfe600b51723934d801850"
-  },
-  {
-    "version": "4.1.1-rc.9",
-    "container_hash": "027d1ef295e27ff81c3aee70b015afbd9b0c91f7546172d2a73671a2efff6ce3",
-    "git_hash": "ef2322ea6b9b8d4922e86993956179fcac93ee6e"
-  },
-  {
     "date": "2022-03-22",
     "version": "4.1.2"
   },
@@ -1630,36 +610,6 @@
     "git_hash": "b8a56d2f25cd6340748805490be7f85ae25cc48d"
   },
   {
-    "version": "4.1.2-rc.2",
-    "container_hash": "3ec720f245451615ac1dab718f2dfc1435315d71c398fba761505371fe9390db",
-    "git_hash": "5100d93b63128f8755fb46409f8955744836f1fc"
-  },
-  {
-    "version": "4.1.3-rc.3",
-    "container_hash": "f903aa7ff42c9e8e0353b5186af769a0672b988a14c49737229d6c6dcb6fdd14",
-    "git_hash": "cb4b8f409717e715b26b988d8ce03e089cc1fa78"
-  },
-  {
-    "version": "4.1.3-rc.4",
-    "container_hash": "b2b7686d7eb324d3be9c632b846397bc81a8a83f913a460ad605376d0ec5dd38",
-    "git_hash": "5e214e6bea262292e96d5a5127cb955d2665a31e"
-  },
-  {
-    "version": "4.1.3-rc.5",
-    "container_hash": "9720ebb0bab72ab2b9e81c9c46c6c233082db15dc20a890291b881c8a7c8fc4e",
-    "git_hash": "9c9ebb5b52a9a803212bb8be5d42d332eda21278"
-  },
-  {
-    "version": "4.1.3-rc.6",
-    "container_hash": "da7a2a39e59f412feed0cbe18fa7e3ce099cadee73420112aa5a18b481c53df1",
-    "git_hash": "ce108a065fb5e84a437e8b0ec17e6485dcec637f"
-  },
-  {
-    "version": "4.1.3-rc.7",
-    "container_hash": "00e76524d6e527dd9341c34e6294cc7123a5731d90ea8369796745197cb8c54b",
-    "git_hash": "019ea414214b6e1d6833dda7a636342a55f7d8f8"
-  },
-  {
     "date": "2022-04-04",
     "version": "4.2.0",
     "container_hash": "569f68c390e4db811c895d30da9d746f15d3853fb96b0becb452181b0d6be095",
@@ -1674,39 +624,6 @@
     "version": "4.2.0",
     "container_hash": "c1307a71d569bb2d5833c8d55cdc32acba51cb12cd2141b996ca23d33e860ba4",
     "git_hash": "42ddbc60f1028b78967ecd9b4da66f948eef152b"
-  },
-  {
-    "version": "4.2.1-rc.0",
-    "container_hash": "6bd2b719da40816e5af36e6622e75d527c5ea26713744d2be24704c9143c869e",
-    "git_hash": "12d5ceeac4e90ef187d2840562e41b03a0fbf481"
-  },
-  {
-    "version": "4.2.1-rc.1",
-    "container_hash": "bb8058dca3c91fbe4c852f1a44f010a91b446c8a77005c15ce6963f891522771",
-    "git_hash": "e25ebee9f2adc31d06b7d79cea21494031dd4c27"
-  },
-  {
-    "version": "4.2.1-rc.2",
-    "container_hash": "b81fcaeba662afb78704e657e0216bfc02409bbde20bd2676715cb116cce86ff",
-    "git_hash": "380d7fdb6419144ce1417927e7432f648de5624b"
-  },
-  {
-    "date": "2022-04-08",
-    "version": "pr-531-Add-rebuild-workflow-and-update",
-    "container_hash": "7e1e2b1ea387bfb250752a706511bafac982b90af7a0fbe3004445da5863e5b4",
-    "git_hash": "62074fa7196bacc9aa5301db7052c78e3422bd56"
-  },
-  {
-    "date": "2022-04-14",
-    "version": "4.2.1-rc.6",
-    "container_hash": "64b7ed0a5f8dc809ec803e94846cd8cb016926717e40b5da3dcbeed9a0907741",
-    "git_hash": "02ff32ebdbd365d2a6c2e3228738d410e4cd325c"
-  },
-  {
-    "date": "2022-04-18",
-    "version": "4.2.1-rc.7",
-    "container_hash": "6ee7f10789e956835bfc195062f1043f8f5f80219701a3a25eb49f3d5ea96981",
-    "git_hash": "478a4b0751f5d51f28224400e533b98cb410358d"
   },
   {
     "date": "2021-10-21",
@@ -1751,30 +668,6 @@
     "git_hash": "a5fdbcb05057195e487b299068d1869dd923260d"
   },
   {
-    "date": "2022-04-20",
-    "version": "4.2.1-rc.8",
-    "container_hash": "3dca7a68d495eb813ec277baf58e230704fcf5cb8198ffa79c67b44e3d9221f1",
-    "git_hash": "fd7a4398b179c006c715926e37d8544f9559edfc"
-  },
-  {
-    "date": "2022-04-21",
-    "version": "4.2.1-rc.9",
-    "container_hash": "aefd4b5b8a884ff8b6df3dbd4f016e106a23aabdba0bb004d7852f7ebeb12977",
-    "git_hash": "b0e40128e7f70896e8c4b3ee1d649fed0808b81c"
-  },
-  {
-    "date": "2022-04-21",
-    "version": "4.2.1-rc.10",
-    "container_hash": "02741ce3035845860005d801e935f8d94bcb63547d00b362e635118ed158f501",
-    "git_hash": "fbf4e1bd886f5006f584f4cc980089a751a67847"
-  },
-  {
-    "date": "2022-04-25",
-    "version": "4.2.1-rc.11",
-    "container_hash": "e3da15b4fc198f83bce06016e6d5130c21a6470d78d099ec3fc1400e0db9986c",
-    "git_hash": "cbb581f4afa4e6224345c0c93b6451ba3dafdf53"
-  },
-  {
     "date": "2022-04-26",
     "version": "4.0.0",
     "container_hash": "ce477ffc42523ec8f307ae6c16db561c2a878f38be034b2d1c33c79df75aa34a",
@@ -1803,30 +696,6 @@
     "version": "4.1.0",
     "container_hash": "4522288ebc886604bd8f3f2e19c8c8e86d5dfe3e845ef44eadfc07261567a95e",
     "git_hash": "a5fdbcb05057195e487b299068d1869dd923260d"
-  },
-  {
-    "date": "2022-04-27",
-    "version": "4.2.1-rc.12",
-    "container_hash": "e3d730fb24f5093cd2f7d3c78cd2e9d27eefbb78d5ae77ede88966f2ba8abf6e",
-    "git_hash": "c5c16cee1aa82f9a838d9d6b90cf6f385351feaa"
-  },
-  {
-    "date": "2022-04-28",
-    "version": "4.2.1-rc.13",
-    "container_hash": "a58d09d608c95e3925d6c145beaed0f79807b5cf32c9890be9229ed0c67262b0",
-    "git_hash": "6a3c11d73a2b610a6f3dc95ab2d8297c9ffe8a28"
-  },
-  {
-    "date": "2022-04-29",
-    "version": "4.2.1-rc.14",
-    "container_hash": "65aa1f0a37c0edbfce41ade633a5f8a6c57c098cbfcf33daa2cb28d26c5cd575",
-    "git_hash": "0a779878cf6dc9f248928f68af9cf8f3a843505f"
-  },
-  {
-    "date": "2022-05-02",
-    "version": "4.2.1-rc.15",
-    "container_hash": "e51bf16bc603e943390a0874a3a33c4245f4653869bb9ce93afa897c8cd78cc4",
-    "git_hash": "3e1e2d6e75b9f8d1b4d1ea000bfa30be18863c72"
   },
   {
     "date": "2022-05-03",
@@ -1859,34 +728,10 @@
     "git_hash": "1495ee1d2b82bc733974d61e3ccf29522fca6f33"
   },
   {
-    "date": "2022-05-03",
-    "version": "4.2.1-rc.16",
-    "container_hash": "8a414b79a43eb8b3ea544b74f4726b5b468794f822c3ae9ce5727572bc80e7aa",
-    "git_hash": "f1b90bb5388ba40620043b568b14fc3c125465ce"
-  },
-  {
-    "date": "2022-05-05",
-    "version": "4.2.1-rc.17",
-    "container_hash": "92bae5b58921ab661cb3d5ee7b861c7ac24f081a832a9cd55eb4f4d4e9fed905",
-    "git_hash": "766b7ad5ad5b26a639aa1049c679c33a36ca23e2"
-  },
-  {
-    "date": "2022-05-05",
-    "version": "4.2.1-rc.18",
-    "container_hash": "8a98fee9b378d0291d18586aa367ac2cb3a2a19aceb3fac174093dc80051ee45",
-    "git_hash": "7385bd3e2755855a1704d0bebfda13090427fcf3"
-  },
-  {
     "date": "2022-05-08",
     "version": "4.3.0",
     "container_hash": "04d19d95cc19d017786f637682e4122944c92747c316ae926d96576002fbdade",
     "git_hash": "caaeee1dffd4985ebde042122d4ac3c4c0053f83"
-  },
-  {
-    "date": "2022-05-09",
-    "version": "4.3.1-rc",
-    "container_hash": "2f9b5f647ab7f0b19513b81319c5c3dd5aec1da3b550461fd4b50c837dd60282",
-    "git_hash": "e7231dbf36ef62469105df76c540ee83528b513a"
   },
   {
     "date": "2022-05-10",
@@ -1925,18 +770,6 @@
     "git_hash": "caaeee1dffd4985ebde042122d4ac3c4c0053f83"
   },
   {
-    "date": "2022-05-13",
-    "version": "4.3.2-rc",
-    "container_hash": "6183842e019ec58f57034a23c28a7253c1d22fccb9fbf81c2d196816e58edf1a",
-    "git_hash": "3ac935dd6cf2a0874ac12ec69f6c938815cfdcc9"
-  },
-  {
-    "date": "2022-05-16",
-    "version": "4.3.3-rc",
-    "container_hash": "f2f93ce0a005239fd939348e1a288f23103989c8b5325e83939c47341ba6ad82",
-    "git_hash": "c884cc01ce6687c0dcb9772d7f8460b57d495585"
-  },
-  {
     "date": "2022-05-17",
     "version": "4.0.1",
     "container_hash": "d46bb429e3978cf4ec94d8a32c36faab6970748bbe19de59fbac3f39c22b3d12",
@@ -1971,24 +804,6 @@
     "version": "4.3.0",
     "container_hash": "18c1122df9e2dc1fa742304f63fd3e282535d7b55765950c67554605ad7a6546",
     "git_hash": "caaeee1dffd4985ebde042122d4ac3c4c0053f83"
-  },
-  {
-    "date": "2022-05-23",
-    "version": "4.3.4-rc",
-    "container_hash": "7b20f0c255201337e61840c4c257cd6ebb89b00998481966bd8ff2e1352806ba",
-    "git_hash": "bfb0f11764e5f8a4cf8a783c7c1602042d3da869"
-  },
-  {
-    "date": "2022-05-23",
-    "version": "4.3.5-rc",
-    "container_hash": "308593cf3a1b8a7ee7021105d9a18d35b8f221dc30ff6d50c37dcca8712a9c6a",
-    "git_hash": "c2648f39a733773a8411db9a99668c0d1526b39d"
-  },
-  {
-    "date": "2022-05-24",
-    "version": "4.3.6-rc",
-    "container_hash": "0330ddbf9213d785486aaab5736f608409e261018fef265ec8d6f815f0ddcbc5",
-    "git_hash": "909224e205cc5c98b6d223152b4b82a054642651"
   },
   {
     "date": "2022-05-24",
@@ -2058,75 +873,9 @@
   },
   {
     "date": "2022-05-31",
-    "version": "4.4.1-rc",
-    "container_hash": "9551514be23cc78d0f027849eed8eefc2e1ac18419afb73006d16d632ae810c6",
-    "git_hash": "512aa8ebcb8aae461f9ee2760f144eb46d60eeb8"
-  },
-  {
-    "date": "2022-05-31",
     "version": "4.4.1",
     "container_hash": "c19b52ad26a0777bd813e53730ec29f457170e9934b4fdfa44b3dac24a6d0051",
     "git_hash": "de11e34bf6b401fe5c5464a57a547e6f3ea23db3"
-  },
-  {
-    "date": "2022-06-01",
-    "version": "4.4.2-rc.0",
-    "container_hash": "c53d01541e0db4cbcf6adb842c89bdbc05bbeb7367f4ba7615c5f9c6c524ae38",
-    "git_hash": "ff343a8f766bb078bc29adaee1e61ea7e32c14df"
-  },
-  {
-    "date": "2022-06-02",
-    "version": "4.4.2-rc.1",
-    "container_hash": "2628859cdf19396d542a14b8d1dcd9f9593882e84745d92da8f9c315cd013a81",
-    "git_hash": "f9cabadd6018e219c0f91c65e9e989c50975e2ea"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "4.4.2-rc.2-amd64",
-    "container_hash": "9040b3cba3b5db1e349925ff8ac0c6166283697c7011749b9c7d147753551087",
-    "git_hash": "eb139903d3928d7cdd32af49ffa46cc038d05d20"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "4.4.2-rc.2-arm64",
-    "container_hash": "197bfea9b4527c6ca533f18a2f8fc3d7a8d94320890d32a124f34e6161d9e3a7",
-    "git_hash": "eb139903d3928d7cdd32af49ffa46cc038d05d20"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "4.4.2-rc.3-amd64",
-    "container_hash": "5a91f43f942c18e816f4ae5311488de091fc590607b2a00be558ea9221307efb",
-    "git_hash": "fb5583038fdedada077b39d19a46b26a963b5d1c"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "4.4.2-rc.3-arm64",
-    "container_hash": "e12623a7f9a20c80afd50c01bf86165b75acd42241076d079f6ab6a5e887c755",
-    "git_hash": "fb5583038fdedada077b39d19a46b26a963b5d1c"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "4.4.2-rc.4-amd64",
-    "container_hash": "877a0d6fec86d72e873ebec1ab929d65b703b83de980e338e433bb694726c1f6",
-    "git_hash": "d3589cc742395bae9e1d2b77ce2adae17f00547d"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "4.4.2-rc.5-amd64",
-    "container_hash": "59b40979023940d7e60bf65fd85112c6e6612495ea93b435594afcd5c3e22306",
-    "git_hash": "9726252d926740a6609393e2d12c0480cc76ec72"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "4.4.2-rc.4-arm64",
-    "container_hash": "0175da44220ff707b75f4dc8f38b639cb19c5d9bf60bb5b46add9059fe813531",
-    "git_hash": "d3589cc742395bae9e1d2b77ce2adae17f00547d"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "4.4.2-rc.5-arm64",
-    "container_hash": "2526740f6c9c9658375047f0578dc9bc5c8cfc93abcf88cb42c4b67b66282188",
-    "git_hash": "9726252d926740a6609393e2d12c0480cc76ec72"
   },
   {
     "date": "2022-06-03",
@@ -2139,18 +888,6 @@
     "version": "4.4.2-arm64",
     "container_hash": "a434e7b899332deaf61498ddfa8d724f5ce19395fc80b3d0e9328e02acde749e",
     "git_hash": "c5da99a20be1bacaa605e952c1963ebf17d44000"
-  },
-  {
-    "date": "2022-06-06",
-    "version": "4.4.3-rc.0-amd64",
-    "container_hash": "e495993e48e4e2109269edb3014ab49dee14c01c33331904b6b7cbc5b42d79a6",
-    "git_hash": "0cb6adc8d3d1e90659eba41e9b5951262d9c4952"
-  },
-  {
-    "date": "2022-06-06",
-    "version": "4.4.3-rc.0-arm64",
-    "container_hash": "04893b2dd78eb22a54acafb724f30ba3eb7fedfbaddbc284d39ac60a79444241",
-    "git_hash": "0cb6adc8d3d1e90659eba41e9b5951262d9c4952"
   },
   {
     "date": "2022-06-07",
@@ -2273,72 +1010,6 @@
     "git_hash": "c5da99a20be1bacaa605e952c1963ebf17d44000"
   },
   {
-    "date": "2022-06-14",
-    "version": "4.4.3-rc.4-amd64",
-    "container_hash": "c4a425a9bb2c70c3c599bc423d9dde487cdbb2e20cdf579f6f88f18721e5ad2d",
-    "git_hash": "5278d8a4821107e7d662c13993fcbc1e9156a396"
-  },
-  {
-    "date": "2022-06-16",
-    "version": "4.4.3-rc.5-arm64",
-    "container_hash": "a4fbe0cba5fdcf7026d7b07f3b52845b64e4eb2253d02604ae5b042caf84798c",
-    "git_hash": "cf5504ea07bb25da3f595768243eab9d901c579c"
-  },
-  {
-    "date": "2022-06-16",
-    "version": "4.4.3-rc.5-amd64",
-    "container_hash": "e251100f66606f9dd230fa2d85fe0b4166745f24a9c48af574a1fcfc90741a98",
-    "git_hash": "cf5504ea07bb25da3f595768243eab9d901c579c"
-  },
-  {
-    "date": "2022-06-16",
-    "version": "4.4.3-rc.6-arm64",
-    "container_hash": "708f6e148256c80f88859b3a03cd4c7d153546bce36281e1fd426cdd725a7989",
-    "git_hash": "012b5daf76dd00eec8380b021564cd92b7038d5b"
-  },
-  {
-    "date": "2022-06-16",
-    "version": "4.4.3-rc.6-amd64",
-    "container_hash": "6f5a161cc88fbc0fab8811207d5fa9dc2bd1eea9484112b65fe17481bc367439",
-    "git_hash": "012b5daf76dd00eec8380b021564cd92b7038d5b"
-  },
-  {
-    "date": "2022-06-17",
-    "version": "4.4.3-rc.7-arm64",
-    "container_hash": "124600afc1cf2c3c33192a3e55225786934dc54927164ab532f90579718dcdc4",
-    "git_hash": "66574ab2a5fca093232f9f28da29352263ccd937"
-  },
-  {
-    "date": "2022-06-17",
-    "version": "4.4.3-rc.7-amd64",
-    "container_hash": "449cf38981a2a1ce830c26f2bd9c2aac922dc7eb29b3da7bf1c1b5aeaa24c13b",
-    "git_hash": "66574ab2a5fca093232f9f28da29352263ccd937"
-  },
-  {
-    "date": "2022-06-17",
-    "version": "4.4.3-rc.8-arm64",
-    "container_hash": "d110550badcd23304c90434e33cdff46949a2c1ab5b5b409dd1cbbd03f20bb10",
-    "git_hash": "2c5770cbc43c5242d7f7ff6dcd5e140a4aab7e2e"
-  },
-  {
-    "date": "2022-06-17",
-    "version": "4.4.3-rc.8-amd64",
-    "container_hash": "1202a987db813cf9955ccb80d94f7c55696c55e052bca453ed08d5038272cbbb",
-    "git_hash": "2c5770cbc43c5242d7f7ff6dcd5e140a4aab7e2e"
-  },
-  {
-    "date": "2022-06-20",
-    "version": "4.4.3-rc.9-arm64",
-    "container_hash": "34ab33e8cac571881f95dc16b41081ada4e8a51a355b1fa862155894d6253fb6",
-    "git_hash": "3b44468079109ceb2a7c7ef130d6dd23ca6c3250"
-  },
-  {
-    "date": "2022-06-20",
-    "version": "4.4.3-rc.9-amd64",
-    "container_hash": "fcc9ba436e77afd31d7e31f84687b9d0414c0aa7aaf7b97a9449f2ecd97c0eee",
-    "git_hash": "3b44468079109ceb2a7c7ef130d6dd23ca6c3250"
-  },
-  {
     "date": "2022-06-21",
     "version": "4.2.0",
     "container_hash": "79bb76a7c6648cc2c302e4229b15e059e8ec7265ff1b35a692ebcc032a93dabd",
@@ -2385,18 +1056,6 @@
     "version": "4.1.2",
     "container_hash": "11d725aa4fed9532c47408dfc7a08ee8f92eebd5073175e1fdfebd75b53a6db7",
     "git_hash": "a0ad2b9f164b7ec1dec484e63cb7baa3ae7fe256"
-  },
-  {
-    "date": "2022-06-23",
-    "version": "4.4.3-rc.10-arm64",
-    "container_hash": "7f7b8abf5e682b775458429b717fe395fea512e1f5416863efbd8ecc071da1ef",
-    "git_hash": "a34cae0c56609b67471f27ec4fe2d25119963c3e"
-  },
-  {
-    "date": "2022-06-23",
-    "version": "4.4.3-rc.10-amd64",
-    "container_hash": "56928f596c9c6c751f256adf18372a38f751b7ff3de1007642c12f12d54cfe1e",
-    "git_hash": "a34cae0c56609b67471f27ec4fe2d25119963c3e"
   },
   {
     "date": "2022-06-28",
@@ -2451,42 +1110,6 @@
     "version": "4.3.0",
     "container_hash": "a5df9af2e88e16141df7d3a4a59e950f28be970a9af9c80d7662f0033a7b4571",
     "git_hash": "caaeee1dffd4985ebde042122d4ac3c4c0053f83"
-  },
-  {
-    "date": "2022-06-30",
-    "version": "4.4.3-rc.11-arm64",
-    "container_hash": "3d5ff5bc5f4a6cbb48346ec3613be1a5947f428fec3842a76345b087a9ebfd38",
-    "git_hash": "e67ce1ed3befce3ce138b260d3ccfb5241efd01e"
-  },
-  {
-    "date": "2022-06-30",
-    "version": "4.4.3-rc.12-amd64",
-    "container_hash": "ec87ae312dd2182cab21a1055b7a1a76be2f072afd0259b93699bf106d0f6dad",
-    "git_hash": "94d0239d66f8beef36deba2e3ed077a6d243ff43"
-  },
-  {
-    "date": "2022-06-30",
-    "version": "4.4.3-rc.12-arm64",
-    "container_hash": "d00a5a06ae62386052d8b21643a14bc2d7eaa31df31e8be98e763d95780ce3ba",
-    "git_hash": "94d0239d66f8beef36deba2e3ed077a6d243ff43"
-  },
-  {
-    "date": "2022-06-30",
-    "version": "4.4.3-rc.11-amd64",
-    "container_hash": "b54a0d5f074e767f9bd9f6f52ce19afee09be963b2d22c294afbe4f81d6bad30",
-    "git_hash": "e67ce1ed3befce3ce138b260d3ccfb5241efd01e"
-  },
-  {
-    "date": "2022-07-04",
-    "version": "4.4.3-rc.13-amd64",
-    "container_hash": "201a20bd0917072807c502e59060e09b6b7aa9ec0e72ce64538615f70a9883cd",
-    "git_hash": "8c6d455f8ebd8035c766d9ad0b501b72b0a13ffa"
-  },
-  {
-    "date": "2022-07-04",
-    "version": "4.4.3-rc.13-arm64",
-    "container_hash": "4666f5a46f6e4163757b914b0d571d6613da1c019e1f9fc7a856cec748a66d69",
-    "git_hash": "8c6d455f8ebd8035c766d9ad0b501b72b0a13ffa"
   },
   {
     "date": "2022-07-05",
@@ -2549,18 +1172,6 @@
     "git_hash": "c5da99a20be1bacaa605e952c1963ebf17d44000"
   },
   {
-    "date": "2022-07-06",
-    "version": "4.4.3-rc.14-arm64",
-    "container_hash": "b6a6bb62908659fe532e0530696787e4fd3c8fe9e3b256e09599c1f144b324f0",
-    "git_hash": "74ffd2e3adb23a6e46e941d08d8826f0abd80914"
-  },
-  {
-    "date": "2022-07-06",
-    "version": "4.4.3-rc.14-amd64",
-    "container_hash": "3b6f113f0d43833e93cc86fa9e9a66c3c834d9e35c7c216c200e4f85eac729ce",
-    "git_hash": "74ffd2e3adb23a6e46e941d08d8826f0abd80914"
-  },
-  {
     "date": "2022-07-07",
     "version": "4.4.2-arm64",
     "container_hash": "2a1730571ed7cc73db32536c898cc1c38910122484f20cd0f72ac2b0ed3155b1",
@@ -2621,30 +1232,6 @@
     "git_hash": "1495ee1d2b82bc733974d61e3ccf29522fca6f33"
   },
   {
-    "date": "2022-07-07",
-    "version": "4.4.3-rc.15-arm64",
-    "container_hash": "757825b09fe17b31fe02cacc306f84c8592db13343cc1a391e25aa8a882a9d17",
-    "git_hash": "09e2962b7f34f929c4355a5627cd1d6f27f6250c"
-  },
-  {
-    "date": "2022-07-07",
-    "version": "4.4.3-rc.15-amd64",
-    "container_hash": "ee641402024c2120bed5d1d97a2389c4f0fd7036916950dd306ec4766452c3b8",
-    "git_hash": "09e2962b7f34f929c4355a5627cd1d6f27f6250c"
-  },
-  {
-    "date": "2022-07-07",
-    "version": "4.4.3-rc.16-arm64",
-    "container_hash": "4979d671adc2dab4e2e8835e87c8e928eabc33bfffc15ebfa643b85f4a273e4d",
-    "git_hash": "fb04e3dfc3d9919d97d0a86f3b5b25c93244c61e"
-  },
-  {
-    "date": "2022-07-07",
-    "version": "4.4.3-rc.16-amd64",
-    "container_hash": "a51ed0f459eee3794d75057749385cc1a9a1004d19db4b37fc16edda1c5d3fc0",
-    "git_hash": "fb04e3dfc3d9919d97d0a86f3b5b25c93244c61e"
-  },
-  {
     "date": "2022-07-12",
     "version": "4.4.2-arm64",
     "container_hash": "f763d74538a3454080c2c51b512e4a0b80ffd922f5aed8aa59cb768859580776",
@@ -2703,30 +1290,6 @@
     "version": "4.3.0",
     "container_hash": "0e0bde773f3ffe9c50766b4458ced469a34fa7301f6862e5c103ea75d188797a",
     "git_hash": "caaeee1dffd4985ebde042122d4ac3c4c0053f83"
-  },
-  {
-    "date": "2022-07-14",
-    "version": "4.4.3-rc.17-arm64",
-    "container_hash": "b10c1f1f189dad90773d314401f805a4f70d0af3b6be0457037421b8379be1af",
-    "git_hash": "e03890344df3dfc0ea36f5127941c0771e5495e3"
-  },
-  {
-    "date": "2022-07-14",
-    "version": "4.4.3-rc.17-amd64",
-    "container_hash": "63d3cb1cfc7170ddfde38dd36363ff23d424c118dd447773e30f05de781e1cfd",
-    "git_hash": "e03890344df3dfc0ea36f5127941c0771e5495e3"
-  },
-  {
-    "date": "2022-07-14",
-    "version": "4.4.3-rc.18-arm64",
-    "container_hash": "ab362b8901c326a99e72eb4b4a05b91c8fecfb74d3f934c27dce3222206d19d9",
-    "git_hash": "433a6f2adc88975498dde0302c0819b7f2d371d7"
-  },
-  {
-    "date": "2022-07-14",
-    "version": "4.4.3-rc.18-amd64",
-    "container_hash": "36dcd488cab65f4aadc45d5b906e1ee543e9c9c9b5c35f71268ad9995484bd2d",
-    "git_hash": "433a6f2adc88975498dde0302c0819b7f2d371d7"
   },
   {
     "date": "2022-07-15",
@@ -2921,42 +1484,6 @@
     "git_hash": "47d4b501aa758bd7c92adf7e4b2cf4355839b4d8"
   },
   {
-    "date": "2022-07-21",
-    "version": "4.4.3-rc.19-arm64",
-    "container_hash": "736d2348b100e457a16bc41eabacb18fbd4eb104c52f4ba78046991c8bf49d4b",
-    "git_hash": "79ddb3288b72aa981e607058d4bad0c726a8a888"
-  },
-  {
-    "date": "2022-07-21",
-    "version": "4.4.3-rc.19-amd64",
-    "container_hash": "8040b4c31eaff63b52be966662445e6dec5e6ca4cff7e0fcd7a36899635ef64f",
-    "git_hash": "79ddb3288b72aa981e607058d4bad0c726a8a888"
-  },
-  {
-    "date": "2022-07-21",
-    "version": "4.4.3-rc.20-amd64",
-    "container_hash": "6494aac9c4fd9e064027d04e9623a931c16b9f48bf7330789188403d11f21a99",
-    "git_hash": "185ef5d0ff14f3ef4ab617bb9b9d174a8cbbb35e"
-  },
-  {
-    "date": "2022-07-21",
-    "version": "4.4.3-rc.20-arm64",
-    "container_hash": "3817ca5acbac5df7e5bb8a77cb5a254c7bbc622b0768c99db51444593e5b564d",
-    "git_hash": "185ef5d0ff14f3ef4ab617bb9b9d174a8cbbb35e"
-  },
-  {
-    "date": "2022-07-22",
-    "version": "4.4.3-rc.21-arm64",
-    "container_hash": "bf4aa08b40a96c6b0bdde6eb2bad8affa7fc183ecb435d251a345611e756ebb2",
-    "git_hash": "1b83d1ca4864293ffdcb42da05f85e28082c19df"
-  },
-  {
-    "date": "2022-07-22",
-    "version": "4.4.3-rc.21-amd64",
-    "container_hash": "deda3de9989828b2e55ef250c3e7131bbb87f76595bb1069148e6054c02eb1f5",
-    "git_hash": "1b83d1ca4864293ffdcb42da05f85e28082c19df"
-  },
-  {
     "date": "2022-07-26",
     "version": "4.4.2-arm64",
     "container_hash": "328a0b683624c532d4a17db0c87353d312001df0ea47eec77328186313a862e5",
@@ -3077,90 +1604,6 @@
     "git_hash": "d0b9ba164af50f663824f83088d89bd367e0f6e7"
   },
   {
-    "date": "2022-08-04",
-    "version": "4.4.3-rc.22-arm64",
-    "container_hash": "5bbe1d55e3cebf512ac4914242474ed301b488b1d4c8f7417f40a9908122b469",
-    "git_hash": "6f30269d3984c6ed9140c12864766b387dbd9093"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "4.4.3-rc.22-amd64",
-    "container_hash": "90a6114db1d75bf60846cbad53a50800fdac3cdbdeb76500118ac4404fb0421e",
-    "git_hash": "6f30269d3984c6ed9140c12864766b387dbd9093"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "4.4.3-rc.23-arm64",
-    "container_hash": "d8052e7723d1ed4daf6cc2789356727d88fdca5a823283ec5d4b34fdbf062488",
-    "git_hash": "8931733e56f673b2341cf40545bb50b4cbd58272"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "4.4.3-rc.23-amd64",
-    "container_hash": "47a73373059324b2ba8dfdc44e679352bdbc7a93c9f1efd9ffaef28bd9b2faa3",
-    "git_hash": "8931733e56f673b2341cf40545bb50b4cbd58272"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "4.4.3-rc.24-arm64",
-    "container_hash": "80f33fee9b686ff1850a3cdeb5b987f40487863e28c284b2884bf14b799935f4",
-    "git_hash": "c3ff6a52e0367497e4f328b14e909aae3d5651c7"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "4.4.3-rc.24-amd64",
-    "container_hash": "d81558fe78c8f020f64a0a871ab36c64f05e73913213bf18a663db438723cc18",
-    "git_hash": "c3ff6a52e0367497e4f328b14e909aae3d5651c7"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "4.4.3-rc.25-arm64",
-    "container_hash": "913d951ad0060bf055149b34e4667b13533765fccfe39061fa02892f284b540c",
-    "git_hash": "3736d9d03da8a8d55031a7eece5d8fb75d56b2c1"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "4.4.3-rc.25-amd64",
-    "container_hash": "ef431e7a474b9b012b3062bb965162974e734c6b528a7aea3925f00324a69c44",
-    "git_hash": "3736d9d03da8a8d55031a7eece5d8fb75d56b2c1"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "4.4.3-rc.26-arm64",
-    "container_hash": "a0bf3844160db34770f59fc4f9bf53076df48c1d9c67f234ea61aa6f892c31a7",
-    "git_hash": "3498216d9b05ba078089f4d100f82b68378bc145"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "4.4.3-rc.26-amd64",
-    "container_hash": "d1e5e698411920743e30ae00baf60a56a314920c04e5228cb94bc642337975f3",
-    "git_hash": "3498216d9b05ba078089f4d100f82b68378bc145"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "4.4.3-rc.27-arm64",
-    "container_hash": "72ad348d01629c379df4c07c83768e90958ef59aa66f065dc406859ee7c9952d",
-    "git_hash": "d682d4f89ea629951cad54223f7b1fb21fe6d095"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "4.4.3-rc.27-amd64",
-    "container_hash": "0e6747d9ed1ac8f79c26ac206fc55ea8cae7ee1082a9daf9ec5ad7a1b402ccd7",
-    "git_hash": "d682d4f89ea629951cad54223f7b1fb21fe6d095"
-  },
-  {
-    "date": "2022-08-05",
-    "version": "4.4.3-rc.28-arm64",
-    "container_hash": "c93e8d1968ca119c132515000d23f1a4361b6fb983b105f314297cfc0e783d36",
-    "git_hash": "f26163bc01aacc4b4cfb8a8cd93e675f5328dc54"
-  },
-  {
-    "date": "2022-08-05",
-    "version": "4.4.3-rc.28-amd64",
-    "container_hash": "7b37b598609616a2790747f76ddfac06db179dc73d0fd8b643ff6af2b76378f2",
-    "git_hash": "f26163bc01aacc4b4cfb8a8cd93e675f5328dc54"
-  },
-  {
     "date": "2022-08-05",
     "version": "4.5.0-arm64",
     "container_hash": "0917f5e0e9f6a57fc6d0a52ef581e9011502f8fe730ec671234add8968c226b5",
@@ -3243,54 +1686,6 @@
     "version": "4.2.0",
     "container_hash": "89c13a0a3c9af4db2259ff44eb97d2692c7123b523b3c711afbb7b63541edf1e",
     "git_hash": "c8cc98818d2d3fcf5d329a708b693e61b10c7730"
-  },
-  {
-    "date": "2022-08-11",
-    "version": "4.5.1-rc.0-arm64",
-    "container_hash": "dbd828516a88f0507b7ed2fc22f8690a076952228e1a77741ac21862a2c39caa",
-    "git_hash": "c15bf48ca13041f25f43ed3c2b5c2b64a243f644"
-  },
-  {
-    "date": "2022-08-11",
-    "version": "4.5.1-rc.0-amd64",
-    "container_hash": "87710cc4b87425aa0848b7ed35874b5865c2ec435e82b0f178b22af130be61a3",
-    "git_hash": "c15bf48ca13041f25f43ed3c2b5c2b64a243f644"
-  },
-  {
-    "date": "2022-08-11",
-    "version": "4.5.1-rc.1-amd64",
-    "container_hash": "4af36f3fb1583a477399e451190d8b86f6c972c572e29d6294a1e38a4930d716",
-    "git_hash": "53918ebcaabd7674d1be3c4b05acc79d62be3492"
-  },
-  {
-    "date": "2022-08-11",
-    "version": "4.5.1-rc.1-arm64",
-    "container_hash": "26f6cadf5fc81e5d3d410f38355439269ee045b25ccff9259f37dfaebe5704bc",
-    "git_hash": "53918ebcaabd7674d1be3c4b05acc79d62be3492"
-  },
-  {
-    "date": "2022-08-11",
-    "version": "4.5.1-rc.2-arm64",
-    "container_hash": "5ad7dc5d8c6d634b09ebaeb6455696b94e34e43e733e1a781b2172cf5c618bb6",
-    "git_hash": "f59e31f7dded0a6647896174976f846f2cb14f79"
-  },
-  {
-    "date": "2022-08-11",
-    "version": "4.5.1-rc.2-amd64",
-    "container_hash": "3d44f690154ed7b96065fe26507036d71680c7d662b9cfe60b39b6b54e1b056b",
-    "git_hash": "f59e31f7dded0a6647896174976f846f2cb14f79"
-  },
-  {
-    "date": "2022-08-15",
-    "version": "4.5.1-rc.3-arm64",
-    "container_hash": "6950fa38802b2b9f76b36f77ebb8791c075a72cc59ba8df9409c196c7f83485b",
-    "git_hash": "a2b365ad7a62df69965f370f5fc1cc14dbd07237"
-  },
-  {
-    "date": "2022-08-15",
-    "version": "4.5.1-rc.3-amd64",
-    "container_hash": "f1430c8bfab43b38a0b6df78c1c520db2dca8eaf5be6be994283d223b640992d",
-    "git_hash": "a2b365ad7a62df69965f370f5fc1cc14dbd07237"
   },
   {
     "date": "2022-08-15",
@@ -3473,18 +1868,6 @@
     "git_hash": "de11e34bf6b401fe5c5464a57a547e6f3ea23db3"
   },
   {
-    "date": "2022-08-25",
-    "version": "4.6.1-rc.0-arm64",
-    "container_hash": "1032d0e562caccc35a819a871278045fa1d298872ae4d4516636fef10fedab83",
-    "git_hash": "ca1776d39a0777e9a5256749460d1f936ccf58ba"
-  },
-  {
-    "date": "2022-08-25",
-    "version": "4.6.1-rc.0-amd64",
-    "container_hash": "9607913cf8b635b75836f26e29ba061beed75507321ec53a905cadfc9a7a10ce",
-    "git_hash": "ca1776d39a0777e9a5256749460d1f936ccf58ba"
-  },
-  {
     "date": "2022-08-30",
     "version": "4.6.0-arm64",
     "container_hash": "8b2ac2db6955d78b1b630d4c56d0dfa48619eadbaa40dd0e94c95aa442d6a3c8",
@@ -3567,42 +1950,6 @@
     "version": "4.0.1",
     "container_hash": "e5c9dd668721bb3830b5fba28176229c16bad258da2066982f0aeb272d2726a4",
     "git_hash": "341273c9b6df07c7c9068e4c7f8dd19a9b535d84"
-  },
-  {
-    "date": "2022-08-30",
-    "version": "4.6.1-rc.1-arm64",
-    "container_hash": "a0f9e068a5b43f3fc75e49f9994c46d1599628ac8ba540d2d0372129b7203e8b",
-    "git_hash": "648000c49f5ada76c606911c46d18364a0a21594"
-  },
-  {
-    "date": "2022-08-30",
-    "version": "4.6.1-rc.1-amd64",
-    "container_hash": "35f6f3265aea0a1ab1cf47658dce10ba948965a6fc573739368748793b42bfee",
-    "git_hash": "648000c49f5ada76c606911c46d18364a0a21594"
-  },
-  {
-    "date": "2022-09-01",
-    "version": "4.6.1-rc.2-arm64",
-    "container_hash": "53dadb4068457e92265aecfd8be05f832832f85a2c44b11bcee67f9e45274603",
-    "git_hash": "2dc202d68e32811bee7c09e4f2d2cf3067d89c37"
-  },
-  {
-    "date": "2022-09-01",
-    "version": "4.6.1-rc.2-amd64",
-    "container_hash": "abfd3cdbae425b261e7dd2688f7d7437909424ce15103504346e9cbcb4ea93e3",
-    "git_hash": "2dc202d68e32811bee7c09e4f2d2cf3067d89c37"
-  },
-  {
-    "date": "2022-09-02",
-    "version": "4.6.1-rc.3-arm64",
-    "container_hash": "ee1f371727db003d928b62333ce68e29764e028d28901419891e3762e3d52c91",
-    "git_hash": "0aa0a943d539255a8c1c73289ed28aec31879de1"
-  },
-  {
-    "date": "2022-09-02",
-    "version": "4.6.1-rc.3-amd64",
-    "container_hash": "390e88344450eeebb5e4aa5d141138e18e239e02ea56b758bbf5f822c469c947",
-    "git_hash": "0aa0a943d539255a8c1c73289ed28aec31879de1"
   },
   {
     "date": "2022-09-06",
@@ -3689,54 +2036,6 @@
     "git_hash": "de11e34bf6b401fe5c5464a57a547e6f3ea23db3"
   },
   {
-    "date": "2022-09-07",
-    "version": "4.6.1-rc.4-amd64",
-    "container_hash": "8a7914bc90a92eec7ece803a41823fcebc0ac21b9bf0259917faf475f3d45b56",
-    "git_hash": "fde50f18df44860c847b9c47744d5518d423410e"
-  },
-  {
-    "date": "2022-09-07",
-    "version": "4.6.1-rc.4-arm64",
-    "container_hash": "72c6d51944fe097159d4115b53e33ba21f0505dd096a665d1f630cb899210f5d",
-    "git_hash": "fde50f18df44860c847b9c47744d5518d423410e"
-  },
-  {
-    "date": "2022-09-08",
-    "version": "4.6.1-rc.5-arm64",
-    "container_hash": "92bd3224d6f31e2d3ba9944da4f28106847256fdf4c18d8494cbdd5a5b156fa5",
-    "git_hash": "fcf35b16b32692c194535e5c25336e96582bbe22"
-  },
-  {
-    "date": "2022-09-08",
-    "version": "4.6.1-rc.5-amd64",
-    "container_hash": "0e36ea74992ca7270cec5b44c3502f907abc15482bac30ea6791ebb22ca73e67",
-    "git_hash": "fcf35b16b32692c194535e5c25336e96582bbe22"
-  },
-  {
-    "date": "2022-09-08",
-    "version": "4.6.1-rc.6-amd64",
-    "container_hash": "22ddf926df0da677aef7a89ada350196f97ba7cb81e45a2beaa881446ee305d6",
-    "git_hash": "799924bd1db54efbd8766756a49bc810a4f549da"
-  },
-  {
-    "date": "2022-09-08",
-    "version": "4.6.1-rc.6-arm64",
-    "container_hash": "bd1961f5b1d75ffe4db00014a45a3090c546c97ce5fea1ddfc5a3b353ddc37eb",
-    "git_hash": "799924bd1db54efbd8766756a49bc810a4f549da"
-  },
-  {
-    "date": "2022-09-12",
-    "version": "4.6.1-rc.7-amd64",
-    "container_hash": "47427e15fedc4f9bbfaefcf84020902d0cfa25b12d922d6e71bf9775048ae8b7",
-    "git_hash": "3dfa169f9404d6311fce32166fc437cf84361c1a"
-  },
-  {
-    "date": "2022-09-12",
-    "version": "4.6.1-rc.7-arm64",
-    "container_hash": "9fba515cf8218afbf5c02c4c003840bd8279a2a7c358718ca0c83562f9b29454",
-    "git_hash": "3dfa169f9404d6311fce32166fc437cf84361c1a"
-  },
-  {
     "date": "2022-09-13",
     "version": "4.5.0-arm64",
     "container_hash": "dce0a683b55f77b093894ee78c8a9fc44a8ac2895b19c51ee548c7727e6afdf4",
@@ -3819,30 +2118,6 @@
     "version": "4.4.2-arm64",
     "container_hash": "06ae8ce7366759ea88388f96dc927c57e5ef8ccbdbedf5878c8ee20fc0bb4d80",
     "git_hash": "d0b9ba164af50f663824f83088d89bd367e0f6e7"
-  },
-  {
-    "date": "2022-09-16",
-    "version": "4.6.1-rc.8-amd64",
-    "container_hash": "31ad1879705875ed05338478855af8e50a5e7e396c44c6581e104992da5421f6",
-    "git_hash": "fa4cba061517c0c98986077cb898b21064983e1a"
-  },
-  {
-    "date": "2022-09-16",
-    "version": "4.6.1-rc.8-arm64",
-    "container_hash": "f80bcd3112ef2d43194072fcf4ed81b35da76a92949261c97eb30813647f1b0f",
-    "git_hash": "fa4cba061517c0c98986077cb898b21064983e1a"
-  },
-  {
-    "date": "2022-09-19",
-    "version": "4.6.1-rc.9-arm64",
-    "container_hash": "9f834b2383229402a71b781656f0aa55541ff57a3a8a53870e7edf95dcd7034f",
-    "git_hash": "2bb8c671de1b25aa3601ec1e7e4e23b4211e0b19"
-  },
-  {
-    "date": "2022-09-19",
-    "version": "4.6.1-rc.9-amd64",
-    "container_hash": "0609d8f0cba3f9c09a8f4ac3bf03e5e336e14136849349a2d2a285444410e5b1",
-    "git_hash": "2bb8c671de1b25aa3601ec1e7e4e23b4211e0b19"
   },
   {
     "date": "2022-09-20",
@@ -3929,30 +2204,6 @@
     "git_hash": "61a04d6e7cbd6a4656459c2a4da9cea3c6948449"
   },
   {
-    "date": "2022-09-22",
-    "version": "4.6.1-rc.10-arm64",
-    "container_hash": "ad76b1e7ae62c257af2c217489fe11ea3ce9eba7870310c3672bc756661bca6a",
-    "git_hash": "812baee19bd9dc2b041a1231809459265f4352c4"
-  },
-  {
-    "date": "2022-09-22",
-    "version": "4.6.1-rc.10-amd64",
-    "container_hash": "a08af020dd580c33b18da4a81fa8655e0e4d575d73330ba1c7ff38725ca0ee0f",
-    "git_hash": "812baee19bd9dc2b041a1231809459265f4352c4"
-  },
-  {
-    "date": "2022-09-26",
-    "version": "4.6.1-rc.11-arm64",
-    "container_hash": "f5a0b9219caf637c2d4b8c9353eca838c79cb394106b318c39345f0a73598d4b",
-    "git_hash": "80e203a5f77386a8dd9d7225532704478b3802f4"
-  },
-  {
-    "date": "2022-09-26",
-    "version": "4.6.1-rc.11-amd64",
-    "container_hash": "5405dc81e86bf6becec5c893edf47c953b5688ff135a5164ff2a1e03cd68f590",
-    "git_hash": "80e203a5f77386a8dd9d7225532704478b3802f4"
-  },
-  {
     "date": "2022-09-27",
     "version": "4.6.0-arm64",
     "container_hash": "8b2ac2db6955d78b1b630d4c56d0dfa48619eadbaa40dd0e94c95aa442d6a3c8",
@@ -4026,18 +2277,6 @@
   },
   {
     "date": "2022-09-27",
-    "version": "4.6.1-rc.12-amd64",
-    "container_hash": "84891cbdcdc3bec7ac8adff19ac14e9d5d7294fc6cba81cce7b90f5c5fc0207f",
-    "git_hash": "b9617e403e7aa016601c7dde20725d90877cf119"
-  },
-  {
-    "date": "2022-09-27",
-    "version": "4.6.1-rc.13-amd64",
-    "container_hash": "de2794182faea71c10c215c8ab75ce0627a5794aaa0606f1939be02c758244e1",
-    "git_hash": "776c4fbd3efcada8b9caf42e1bc912c15b8b9010"
-  },
-  {
-    "date": "2022-09-27",
     "version": "4.4.2-arm64",
     "container_hash": "06ae8ce7366759ea88388f96dc927c57e5ef8ccbdbedf5878c8ee20fc0bb4d80",
     "git_hash": "d0b9ba164af50f663824f83088d89bd367e0f6e7"
@@ -4047,54 +2286,6 @@
     "version": "4.5.0-arm64",
     "container_hash": "dce0a683b55f77b093894ee78c8a9fc44a8ac2895b19c51ee548c7727e6afdf4",
     "git_hash": "72d876f29fe59707b35645055fab92d89957dc12"
-  },
-  {
-    "date": "2022-09-27",
-    "version": "4.6.1-rc.12-arm64",
-    "container_hash": "a2f3454f11905bcc215ef34bd7ce8e2595cbd032f43f306d8bfb0854254cef61",
-    "git_hash": "b9617e403e7aa016601c7dde20725d90877cf119"
-  },
-  {
-    "date": "2022-09-28",
-    "version": "4.6.1-rc.13-arm64",
-    "container_hash": "7a008776f12231c97bd8bb5c667253152cb7e7a08627e2bf11d9299c7b72adf6",
-    "git_hash": "776c4fbd3efcada8b9caf42e1bc912c15b8b9010"
-  },
-  {
-    "date": "2022-09-29",
-    "version": "4.6.1-rc.14-amd64",
-    "container_hash": "6f24110018fc0e30bceef5623eb95b3d7507f32b3aa45372a73ec996b302900f",
-    "git_hash": "308596a0b71301da96f4b0e137022ecd3046375d"
-  },
-  {
-    "date": "2022-09-29",
-    "version": "4.6.1-rc.14-arm64",
-    "container_hash": "611f2ef38b4ad5c2c4fc15753cf7af879c1ae87f5430f7ba0f095a03ba03f410",
-    "git_hash": "308596a0b71301da96f4b0e137022ecd3046375d"
-  },
-  {
-    "date": "2022-09-29",
-    "version": "4.6.1-rc.15-arm64",
-    "container_hash": "30bab6dd115d7caa1fcbbbb4fccd99472c481483dba36e69c3ccc24d005c5393",
-    "git_hash": "c6c3e9e0c6a24a50201348eb5842f00f864ec44b"
-  },
-  {
-    "date": "2022-09-29",
-    "version": "4.6.1-rc.15-amd64",
-    "container_hash": "d4906bb9ff8e26e0afdd37b4e862747c008aef1fa19ce3c3324c1a14a1f03ac6",
-    "git_hash": "c6c3e9e0c6a24a50201348eb5842f00f864ec44b"
-  },
-  {
-    "date": "2022-10-03",
-    "version": "4.6.1-rc.16-arm64",
-    "container_hash": "374b296eee54700deb1bd1969c9bd64bea2cde1b40eb69e7d86e2c7324813fcf",
-    "git_hash": "389cd215f790241a7b0111850a6f9a8417d7d6b9"
-  },
-  {
-    "date": "2022-10-03",
-    "version": "4.6.1-rc.16-amd64",
-    "container_hash": "e23d6b88ee7ea1701b39d2b4ccd58018e488952fa810ce83ba837942edf29b9c",
-    "git_hash": "389cd215f790241a7b0111850a6f9a8417d7d6b9"
   },
   {
     "date": "2022-10-04",
@@ -4181,24 +2372,6 @@
     "git_hash": "61a04d6e7cbd6a4656459c2a4da9cea3c6948449"
   },
   {
-    "date": "2022-10-05",
-    "version": "4.6.1-rc.17-arm64",
-    "container_hash": "4c8246cbfa09c12ef0d35c854e45989b1137b31582994c4acfd9402a87f86fad",
-    "git_hash": "eb1040f0c8729a89ecb249b932f3ea5cbe642b7f"
-  },
-  {
-    "date": "2022-10-05",
-    "version": "4.6.1-rc.17-amd64",
-    "container_hash": "b6902de45e58aabeae61714ec9d8e59dd2b40a68a046645cb5814c4d7a3b08ab",
-    "git_hash": "eb1040f0c8729a89ecb249b932f3ea5cbe642b7f"
-  },
-  {
-    "date": "2022-10-10",
-    "version": "4.6.1-rc.18-amd64",
-    "container_hash": "3cc56689106813385aa28ccff0c997974d5318d2472238d5b33afccb962f0fbb",
-    "git_hash": "9e82e5dc67817bfb9995a547336db5f033c6d08f"
-  },
-  {
     "date": "2022-10-11",
     "version": "4.4.2-arm64",
     "container_hash": "06ae8ce7366759ea88388f96dc927c57e5ef8ccbdbedf5878c8ee20fc0bb4d80",
@@ -4283,30 +2456,6 @@
     "git_hash": "caaeee1dffd4985ebde042122d4ac3c4c0053f83"
   },
   {
-    "date": "2022-10-11",
-    "version": "4.6.1-rc.19-arm64",
-    "container_hash": "4078a188a32ffaadabe35118376878993731a0ef039082d4192a9b0a8d1af262",
-    "git_hash": "31bdbc648e5d5397caaabdb2321bdf17259605fc"
-  },
-  {
-    "date": "2022-10-11",
-    "version": "4.6.1-rc.19-amd64",
-    "container_hash": "75be7fad802bb7a5488f004e903298a36af65b152744d3a39f13c76237376bdc",
-    "git_hash": "31bdbc648e5d5397caaabdb2321bdf17259605fc"
-  },
-  {
-    "date": "2022-10-17",
-    "version": "4.6.2-rc.0-amd64",
-    "container_hash": "92a345d14700eb864925e3339d1e1317756bd25431060adaca0d80fd69b3c656",
-    "git_hash": "2f97c5981caf9852ba62105c21b1e92a7b1e3aed"
-  },
-  {
-    "date": "2022-10-17",
-    "version": "4.6.2-rc.0-arm64",
-    "container_hash": "05adc608c81a7e3c456b486f4f00f81b4fe0f19cb34278ff5116feef2937db49",
-    "git_hash": "2f97c5981caf9852ba62105c21b1e92a7b1e3aed"
-  },
-  {
     "date": "2022-10-18",
     "version": "4.6.0-arm64",
     "container_hash": "8b2ac2db6955d78b1b630d4c56d0dfa48619eadbaa40dd0e94c95aa442d6a3c8",
@@ -4385,18 +2534,6 @@
     "git_hash": "d0b9ba164af50f663824f83088d89bd367e0f6e7"
   },
   {
-    "date": "2022-10-18",
-    "version": "4.6.2-rc.1-arm64",
-    "container_hash": "211ac04615c055f665145dc2bd3bd49c5ea645f298525c7dabd813eadc286621",
-    "git_hash": "0a7790cb2c98fb242ed09313b2cdc84e06037ae3"
-  },
-  {
-    "date": "2022-10-18",
-    "version": "4.6.2-rc.1-amd64",
-    "container_hash": "978dde4a64506c038428929b282ba380a81a7c5c6e9399f03c18d2f9380dfd8f",
-    "git_hash": "0a7790cb2c98fb242ed09313b2cdc84e06037ae3"
-  },
-  {
     "date": "2022-10-25",
     "version": "4.1.0",
     "container_hash": "147f7f54eeb87c6ff56a5ba6e9a3cc21a5d80d564e661f9d97f2b0c4a7dfe1e3",
@@ -4461,30 +2598,6 @@
     "version": "4.6.0-arm64",
     "container_hash": "8b2ac2db6955d78b1b630d4c56d0dfa48619eadbaa40dd0e94c95aa442d6a3c8",
     "git_hash": "4c89ac4d891b6c1f6416c2b99a76e8f6d6fe911a"
-  },
-  {
-    "date": "2022-10-31",
-    "version": "4.6.2-rc.2-arm64",
-    "container_hash": "8caad234fc49736d0331f00c05d2e9445ccd5c0e563e63f607e3aedb386a2cd3",
-    "git_hash": "ba4eeb8e146aaa96479d9c132ae6148acbfd6454"
-  },
-  {
-    "date": "2022-10-31",
-    "version": "4.6.2-rc.2-amd64",
-    "container_hash": "8821f3b83ae743e363c436f0fc2248e37252e8c494975875244c3c889e4f1d84",
-    "git_hash": "ba4eeb8e146aaa96479d9c132ae6148acbfd6454"
-  },
-  {
-    "date": "2022-10-31",
-    "version": "4.6.2-rc.3-arm64",
-    "container_hash": "8963db2b683c398f4373dd7add4adcbf58ec81dfbaa85ce1c230622bb6fab0ff",
-    "git_hash": "6b7476ef0c20a021e0ec4a5b57c06b7133821a42"
-  },
-  {
-    "date": "2022-10-31",
-    "version": "4.6.2-rc.3-amd64",
-    "container_hash": "81a6363b1756852b8e7229f54914316a2f948f297527d6a3287e959b2948a921",
-    "git_hash": "6b7476ef0c20a021e0ec4a5b57c06b7133821a42"
   },
   {
     "date": "2022-11-01",
@@ -4571,30 +2684,6 @@
     "git_hash": "47d4b501aa758bd7c92adf7e4b2cf4355839b4d8"
   },
   {
-    "date": "2022-11-03",
-    "version": "4.6.2-rc.4-arm64",
-    "container_hash": "70e424972ad1698edd6f1dd3940337f0d02d06faf6d8cb07f7a034c5fd325fed",
-    "git_hash": "69f456b57144572db6b532cb175d4ed4b7800e33"
-  },
-  {
-    "date": "2022-11-03",
-    "version": "4.6.2-rc.4-amd64",
-    "container_hash": "48ddc0ce4a429f411756cff8685c4f16573fb14f1cbed6b6a68f80ece3b25776",
-    "git_hash": "69f456b57144572db6b532cb175d4ed4b7800e33"
-  },
-  {
-    "date": "2022-11-04",
-    "version": "4.6.2-rc.5-arm64",
-    "container_hash": "ecc7ca85ea3a72fcc8e1e600a3e4dc0d68bc31ac3ec8ff637e8f823907adb4ba",
-    "git_hash": "a9a2e552263a1d04278994a56c39245e756d1f95"
-  },
-  {
-    "date": "2022-11-04",
-    "version": "4.6.2-rc.5-amd64",
-    "container_hash": "e236b4e739815a6acd0ef44bf8d150dcedba1e98993c7439aeaada3eee15f153",
-    "git_hash": "a9a2e552263a1d04278994a56c39245e756d1f95"
-  },
-  {
     "date": "2022-11-07",
     "version": "4.6.1-amd64",
     "container_hash": "060e1769fe8519b1bc7f6f7a66057d1847ec973dddac9b60c27aead11b46491d",
@@ -4605,18 +2694,6 @@
     "version": "4.6.1-arm64",
     "container_hash": "88466185a594a1883ca4c98454f6d18b9cf7e1c98b85ced1683960905b3e8e8f",
     "git_hash": "cb0798251c585dc77bca9565fc77156675f73dc7"
-  },
-  {
-    "date": "2022-11-07",
-    "version": "4.6.2-rc.6-amd64",
-    "container_hash": "b6af37280256f78b4a8ef3243d3818338865ecadda267071c7e8f7fd960bef92",
-    "git_hash": "c6aa320e5d8ff68b7b6e3802fce7e11a87da52a1"
-  },
-  {
-    "date": "2022-11-07",
-    "version": "4.6.2-rc.6-arm64",
-    "container_hash": "244ce4f020e0d9d0372be3a063ea2f56e49da339430030cf61232a0cb9221758",
-    "git_hash": "c6aa320e5d8ff68b7b6e3802fce7e11a87da52a1"
   },
   {
     "date": "2022-11-08",
@@ -4695,18 +2772,6 @@
     "version": "4.6.0-arm64",
     "container_hash": "9a554595c3c3627392a771ba8a4646d78ba282f88e05cda3e11deb8e4ec26dc9",
     "git_hash": "4c89ac4d891b6c1f6416c2b99a76e8f6d6fe911a"
-  },
-  {
-    "date": "2022-11-10",
-    "version": "4.6.2-rc.7-arm64",
-    "container_hash": "8ac75f36fd0dadd05a8506c4eae29bd6b99bf42704d060616c263425281efef7",
-    "git_hash": "94ec3bf4d693e57eb3d1971e70698618aa6ad0dd"
-  },
-  {
-    "date": "2022-11-10",
-    "version": "4.6.2-rc.7-amd64",
-    "container_hash": "cf5428444e700d5d4d1e59d3f7198c85bb088fcb82c54e98577af3a54e3fb1cb",
-    "git_hash": "94ec3bf4d693e57eb3d1971e70698618aa6ad0dd"
   },
   {
     "date": "2022-11-15",
@@ -4805,42 +2870,6 @@
     "git_hash": "d0d2766e9d3140c3a6f6c4740bce446f01301869"
   },
   {
-    "date": "2022-11-17",
-    "version": "4.7.1-rc.0-arm64",
-    "container_hash": "7bc887fdf6415efb8083e1d5597021bfaf6f59b32e99a16684d6d463253e8d85",
-    "git_hash": "709e58f5587034e3a39785f61d0ee6419cc552e3"
-  },
-  {
-    "date": "2022-11-17",
-    "version": "4.7.1-rc.0-amd64",
-    "container_hash": "e1f7903218c2615d58e0049d6e71a00b90642cd7c59b890276dd67fa08bcd77e",
-    "git_hash": "709e58f5587034e3a39785f61d0ee6419cc552e3"
-  },
-  {
-    "date": "2022-11-17",
-    "version": "4.7.1-rc.1-arm64",
-    "container_hash": "5fd20d04c1441bf2e304a9773a5a873a986f7998d647c7b471d6504450b56164",
-    "git_hash": "92d16cd9b2f3354020a7203ad3c8467a9f180b30"
-  },
-  {
-    "date": "2022-11-17",
-    "version": "4.7.1-rc.1-amd64",
-    "container_hash": "f596d63e48a98e0811c4dffd447347bf918821008859da449e6fd0c765dbb4f1",
-    "git_hash": "92d16cd9b2f3354020a7203ad3c8467a9f180b30"
-  },
-  {
-    "date": "2022-11-21",
-    "version": "4.7.1-rc.2-amd64",
-    "container_hash": "223d4e81fb0990b62ac45ef1c28cd0b6277cf668135b9f604ba547aef772d575",
-    "git_hash": "87e38ddd252624781cfd880c8b448ed060dcc39d"
-  },
-  {
-    "date": "2022-11-21",
-    "version": "4.7.1-rc.2-arm64",
-    "container_hash": "effd23eab6f59365c5f73047d18e96d0ebcba6f891e1fd6ea6329e2314b7eb38",
-    "git_hash": "87e38ddd252624781cfd880c8b448ed060dcc39d"
-  },
-  {
     "date": "2022-11-22",
     "version": "4.7.0-arm64",
     "container_hash": "5e0c2060f37284f393c3a26aae545079e7079b0608ec0fe562846a6908cd229f",
@@ -4929,18 +2958,6 @@
     "version": "4.5.0-arm64",
     "container_hash": "4c29d107dc6ee029271977865efb41006e3cab1101f41e361dec9c647aef96ef",
     "git_hash": "72d876f29fe59707b35645055fab92d89957dc12"
-  },
-  {
-    "date": "2022-11-28",
-    "version": "4.7.1-rc.3-arm64",
-    "container_hash": "217d5a004ca6170813cd7549e646cb3ed464792ef3e5686f3a4cce62132832e4",
-    "git_hash": "cbcace88908c2eb2dd68e7a1fb4fdb500eeed4f3"
-  },
-  {
-    "date": "2022-11-28",
-    "version": "4.7.1-rc.3-amd64",
-    "container_hash": "23e71b7a449cfc185efd98b5f820aa69c89b9dde11bdf7e1563f0990b560a905",
-    "git_hash": "cbcace88908c2eb2dd68e7a1fb4fdb500eeed4f3"
   },
   {
     "date": "2022-11-29",
@@ -5039,30 +3056,6 @@
     "git_hash": "de11e34bf6b401fe5c5464a57a547e6f3ea23db3"
   },
   {
-    "date": "2022-12-01",
-    "version": "4.7.1-rc.4-arm64",
-    "container_hash": "e2c8f9860755d10b768ae8bee69c527b2807b57150429ec04b09031bf16e9a23",
-    "git_hash": "6f97c5ee0185256d1f52200a6f90954644af138c"
-  },
-  {
-    "date": "2022-12-01",
-    "version": "4.7.1-rc.4-amd64",
-    "container_hash": "bbab1d1d87e7408816d1e8d8800714e1d67b6d1509f65781683241e2a62d87cd",
-    "git_hash": "6f97c5ee0185256d1f52200a6f90954644af138c"
-  },
-  {
-    "date": "2022-12-05",
-    "version": "4.7.1-rc.5-amd64",
-    "container_hash": "bca65e53d38102becfa5b46cdaf7cd8020a694e7a1112d08b6083558c26da82f",
-    "git_hash": "6143ccc7417f9da8a46719b077871947237f9102"
-  },
-  {
-    "date": "2022-12-05",
-    "version": "4.7.1-rc.5-arm64",
-    "container_hash": "270fac4fd8a91c8a9de2c5ba065f9ef9eede89fd8d27d12f5430c49a66a02316",
-    "git_hash": "6143ccc7417f9da8a46719b077871947237f9102"
-  },
-  {
     "date": "2022-12-06",
     "version": "4.5.0-arm64",
     "container_hash": "4c29d107dc6ee029271977865efb41006e3cab1101f41e361dec9c647aef96ef",
@@ -5145,54 +3138,6 @@
     "version": "4.7.0-amd64",
     "container_hash": "e068717377d536042238166df8aaa3cacffccdb0c8f1444796e7e9f15939eb04",
     "git_hash": "d0d2766e9d3140c3a6f6c4740bce446f01301869"
-  },
-  {
-    "date": "2022-12-08",
-    "version": "4.7.1-rc.6-arm64",
-    "container_hash": "fd7ca5e135fdb34221639c442184e570758d562ce484ac54416743876e7dfbd5",
-    "git_hash": "28ac778a56c66e786d9fe3cb82677879de065691"
-  },
-  {
-    "date": "2022-12-08",
-    "version": "4.7.1-rc.6-amd64",
-    "container_hash": "e2b15ce622dc2edbfa26b2ecfcf647a8a5936cb44267bd174c6af78dd495815c",
-    "git_hash": "28ac778a56c66e786d9fe3cb82677879de065691"
-  },
-  {
-    "date": "2022-12-08",
-    "version": "4.7.1-rc.7-arm64",
-    "container_hash": "20de16fb88762d547c0d8d96435781373cc6568fdb26082e5d2ad7d75b46cfee",
-    "git_hash": "ab11f9d5c40b572de387b070570ed220870f0e77"
-  },
-  {
-    "date": "2022-12-08",
-    "version": "4.7.1-rc.7-amd64",
-    "container_hash": "29fd4281e79120f27b249a35e553af756fa95e761f1811ddd806efe3192799a5",
-    "git_hash": "ab11f9d5c40b572de387b070570ed220870f0e77"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "4.7.1-rc.8-arm64",
-    "container_hash": "46e9cab70692078fd46ca897e1c2904fbf1b39af84ee36dcbcf7de4c5385ea56",
-    "git_hash": "ca70adfe8932477daf8b5fa6d7bb5ad84be9fd41"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "4.7.1-rc.8-amd64",
-    "container_hash": "c7a6148776d6bb423544d99ebcabec87ad1e1d37bc404b01d18d51a6fe2c9325",
-    "git_hash": "ca70adfe8932477daf8b5fa6d7bb5ad84be9fd41"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "4.7.1-rc.9-arm64",
-    "container_hash": "9292eeb624bf51da2ecaf4692a6e071c322972f0d0d6973495667df833cc1e00",
-    "git_hash": "cb6d2fcfa8f41b523f58b98ed2d2997c5e77c8ed"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "4.7.1-rc.9-amd64",
-    "container_hash": "cad9a33d0ca1bde4b0bc90cd97b39f1de1f4d05dd06d8364b5e8972f61400c60",
-    "git_hash": "cb6d2fcfa8f41b523f58b98ed2d2997c5e77c8ed"
   },
   {
     "date": "2022-12-13",
@@ -5283,102 +3228,6 @@
     "version": "4.6.0-arm64",
     "container_hash": "2b868ee9f846804bb1844ec8500d09ece070418477723893684ecaecb689ddf0",
     "git_hash": "4c89ac4d891b6c1f6416c2b99a76e8f6d6fe911a"
-  },
-  {
-    "date": "2022-12-15",
-    "version": "4.7.1-rc.10-amd64",
-    "container_hash": "8a68777860f937621c1759011ea8e4b307e2c0023194a75e0cd47121c5ff9b70",
-    "git_hash": "8cdd0b5be7e751f2609ced135f1591d2b44d0490"
-  },
-  {
-    "date": "2022-12-15",
-    "version": "4.7.1-rc.10-arm64",
-    "container_hash": "5e4e30cc0f78409f0a368a54e021da4c1c97024daf3469cf0e646d58b3f466c1",
-    "git_hash": "8cdd0b5be7e751f2609ced135f1591d2b44d0490"
-  },
-  {
-    "date": "2022-12-20",
-    "version": "4.7.1-rc.11-arm64",
-    "container_hash": "d8f3584a952dd99d821819a12eff68a5a6791e88778e7669c6c9e36140586816",
-    "git_hash": "6e4fce983a310db1fa2ea3a5d20e336d43221a1c"
-  },
-  {
-    "date": "2022-12-20",
-    "version": "4.7.1-rc.11-amd64",
-    "container_hash": "64d67204e44c88c9591417ae18f08a3debc6f8f8047a9006cc95cb8a3fca26ab",
-    "git_hash": "6e4fce983a310db1fa2ea3a5d20e336d43221a1c"
-  },
-  {
-    "date": "2022-12-23",
-    "version": "4.7.1-rc.12-amd64",
-    "container_hash": "cbbe1c737a266b2f1036535ba4a0e4e14ff2dc9c79acd7f62d310f672df1da4c",
-    "git_hash": "632c38349d33aaf42b670d0ddf3734d79cf465d0"
-  },
-  {
-    "date": "2022-12-23",
-    "version": "4.7.1-rc.12-arm64",
-    "container_hash": "a9ab3b9491d5f1214acdb376f122c21caa8daaab8ba2e5af561a11d20409663b",
-    "git_hash": "632c38349d33aaf42b670d0ddf3734d79cf465d0"
-  },
-  {
-    "date": "2023-01-01",
-    "version": "4.7.1-rc.13-arm64",
-    "container_hash": "d76fb703418b14dffdde3f18a6258689ad04767a228075c33da5c03007ddc0cd",
-    "git_hash": "6a5bf824f6a8c08b79625379640c6d41b9a05438"
-  },
-  {
-    "date": "2023-01-01",
-    "version": "4.7.1-rc.13-amd64",
-    "container_hash": "795f209a4a936b9ea59c6b35c8de14a5c4c680752f1f8947472df4b4c07a088a",
-    "git_hash": "6a5bf824f6a8c08b79625379640c6d41b9a05438"
-  },
-  {
-    "date": "2023-01-05",
-    "version": "4.7.1-rc.14-arm64",
-    "container_hash": "313e2b0af3fd33335a4c3afd9b7d4947498b230f9dcf21f51268587b711c9dfd",
-    "git_hash": "576a3482cb6c02dd0a76465465747e6d6894126a"
-  },
-  {
-    "date": "2023-01-05",
-    "version": "4.7.1-rc.14-amd64",
-    "container_hash": "4a379f3c540949c6fc14a74be0deb8ad16357ccaff02f5d6f52ec98970dd55cc",
-    "git_hash": "576a3482cb6c02dd0a76465465747e6d6894126a"
-  },
-  {
-    "date": "2023-01-06",
-    "version": "4.7.1-rc.16-amd64",
-    "container_hash": "fd4ede618f4ee1e3ab23664990a1fca574da00ee9efa1b392de0e4ce3e1c2767",
-    "git_hash": "2015a4e0b471a8a1db14093c2d3aff3c517f9a7a"
-  },
-  {
-    "date": "2023-01-06",
-    "version": "4.7.1-rc.16-arm64",
-    "container_hash": "8ccbdc012636bcb25bd74743abdadcea3db75a5bb51458b62dc29aef62117143",
-    "git_hash": "2015a4e0b471a8a1db14093c2d3aff3c517f9a7a"
-  },
-  {
-    "date": "2023-01-10",
-    "version": "4.7.1-rc.17-amd64",
-    "container_hash": "5a558af3505ae06f767507fbccc4c8eec36ff7796e338bb728057c41f43fa2cd",
-    "git_hash": "7a56aed499f5933bc94413d8bea6351d849dd7a2"
-  },
-  {
-    "date": "2023-01-09",
-    "version": "4.7.1-rc.17-arm64",
-    "container_hash": "1a1a54bd352b0b93b6d2c0d90f5358eca424d442881e9e8b3c86da7357bacc7e",
-    "git_hash": "7a56aed499f5933bc94413d8bea6351d849dd7a2"
-  },
-  {
-    "date": "2023-01-10",
-    "version": "4.7.1-rc.18-amd64",
-    "container_hash": "2d3304692df72c4342a266fc9fc8f6e14b0ab545861b78e01edc22094afc89b3",
-    "git_hash": "0ed21ba1bf52b8f2a203d8075add2fde77644200"
-  },
-  {
-    "date": "2023-01-09",
-    "version": "4.7.1-rc.18-arm64",
-    "container_hash": "475d76766f81a75d9ae64b3eb26f72dbed1b63ac577b153a1eefcc30f06b8bef",
-    "git_hash": "0ed21ba1bf52b8f2a203d8075add2fde77644200"
   },
   {
     "date": "2023-01-10",
@@ -5477,42 +3326,6 @@
     "git_hash": "d0b9ba164af50f663824f83088d89bd367e0f6e7"
   },
   {
-    "date": "2023-01-12",
-    "version": "4.7.1-rc.20-arm64",
-    "container_hash": "e0200e2818308adff9b2cf70613feae115705f0317f858418e74fbb554f0a195",
-    "git_hash": "62a4df98119e5702ff01770c42b336c60c0b4a1b"
-  },
-  {
-    "date": "2023-01-12",
-    "version": "4.7.1-rc.20-amd64",
-    "container_hash": "d76a6d3248641a9364c3dc1eed9766d555909678427b3ce3a87cfd31a5ac8587",
-    "git_hash": "62a4df98119e5702ff01770c42b336c60c0b4a1b"
-  },
-  {
-    "date": "2023-01-12",
-    "version": "4.7.1-rc.22-amd64",
-    "container_hash": "549210a564c624ad94dd324dc1e4229deb2458e2dcd82946b231f4d4b345a18d",
-    "git_hash": "62a1955f2337058d8221b7b0a4e418f103f97a5a"
-  },
-  {
-    "date": "2023-01-12",
-    "version": "4.7.1-rc.22-arm64",
-    "container_hash": "408e747e6b3e7e4cfdee697e0b1fbfc86d7c081d2417a2f7b61bfd85ecc950e4",
-    "git_hash": "62a1955f2337058d8221b7b0a4e418f103f97a5a"
-  },
-  {
-    "date": "2023-01-13",
-    "version": "4.7.1-rc.23-arm64",
-    "container_hash": "a9a0bd16378726e84152039820220ce436c27402a3e3a35c03174a0302a6587f",
-    "git_hash": "eaf7a51a040e986861cb848caa6ddc2861a22f3e"
-  },
-  {
-    "date": "2023-01-13",
-    "version": "4.7.1-rc.23-amd64",
-    "container_hash": "797f96ee53411a7a60dbafc674ab3c8bef614f94ab4aa83f0ba70dac0a6552b2",
-    "git_hash": "eaf7a51a040e986861cb848caa6ddc2861a22f3e"
-  },
-  {
     "date": "2023-01-17",
     "version": "4.5.0-amd64",
     "container_hash": "a549b9face14da44de8a4008151c9f5f139664b178bbbc054598c63b03687cba",
@@ -5609,36 +3422,6 @@
     "git_hash": "4c89ac4d891b6c1f6416c2b99a76e8f6d6fe911a"
   },
   {
-    "date": "2023-01-19",
-    "version": "4.7.1-rc.24-arm64",
-    "container_hash": "4cea5e43ae9a704c296c7770d14b4e964fb7d3676a1dadb3d11b5def0e742e61",
-    "git_hash": "fd5e756e85f3843f44a271bb5a6c55832d3eb330"
-  },
-  {
-    "date": "2023-01-19",
-    "version": "4.7.1-rc.24-amd64",
-    "container_hash": "b8073b774cf44422d942368fd50c31dc3b61b13e0038e181eb7a736867c93c7f",
-    "git_hash": "fd5e756e85f3843f44a271bb5a6c55832d3eb330"
-  },
-  {
-    "date": "2023-01-20",
-    "version": "4.7.1-rc.26-amd64",
-    "container_hash": "08985a5b41716208d7d638d68de334bdd5eeca781691804932e36c7a60f20eae",
-    "git_hash": "0da233e39fa189bf34395429994cb612ff88de4c"
-  },
-  {
-    "date": "2023-01-23",
-    "version": "4.7.1-rc.27-arm64",
-    "container_hash": "8f01060f4465eb474f0307451e43f7e0cf1efe39c5cb2554abbb3413b7c1c41f",
-    "git_hash": "4c0df464e92c6c06e32b7dfa2b5f208f2fc8a951"
-  },
-  {
-    "date": "2023-01-23",
-    "version": "4.7.1-rc.27-amd64",
-    "container_hash": "443a5532b8eca7534c7cd2b48a4d3489add8f4da476ea6aa05bc57a456b5fc13",
-    "git_hash": "4c0df464e92c6c06e32b7dfa2b5f208f2fc8a951"
-  },
-  {
     "date": "2023-01-24",
     "version": "4.1.0",
     "container_hash": "1c7b3dbf896f2d73b1f0de764fbd376b8735972eb711f94bca3e679a4165b204",
@@ -5709,18 +3492,6 @@
     "version": "4.1.2",
     "container_hash": "245ac3fa18276d6daf5ddcba9aa3a42ab6d12e28b6aa0f269aacb257d46c6f88",
     "git_hash": "47d4b501aa758bd7c92adf7e4b2cf4355839b4d8"
-  },
-  {
-    "date": "2023-01-26",
-    "version": "4.7.1-rc.28-arm64",
-    "container_hash": "6897dfadf7c3e7406b0d79724a3f13d4efef0f95e4d0a89a765d321a7666d92f",
-    "git_hash": "1b2aff07544b204f7ce36947d15e9fd8ff4acd51"
-  },
-  {
-    "date": "2023-01-27",
-    "version": "4.7.1-rc.28-amd64",
-    "container_hash": "460fccf09daa1669398aa3bb6f15d1e9f7e6fe3303d397383dbc3a13fbbd57c8",
-    "git_hash": "1b2aff07544b204f7ce36947d15e9fd8ff4acd51"
   },
   {
     "date": "2023-01-31",
@@ -5819,78 +3590,6 @@
     "git_hash": "d0b9ba164af50f663824f83088d89bd367e0f6e7"
   },
   {
-    "date": "2023-01-31",
-    "version": "4.7.1-rc.29-arm64",
-    "container_hash": "b1e03de715ef3fca2dbf5488d6da934cadcf5da2c0263dbd3cb2aa445d263116",
-    "git_hash": "bf9d64e70a4d8b2893c3c03ac718cb4ac1085c32"
-  },
-  {
-    "date": "2023-01-31",
-    "version": "4.7.1-rc.29-amd64",
-    "container_hash": "4176b072ac9a2c81f4391e4f8b117debe4b27fdf62342139196212f3da6bedab",
-    "git_hash": "bf9d64e70a4d8b2893c3c03ac718cb4ac1085c32"
-  },
-  {
-    "date": "2023-02-01",
-    "version": "4.7.1-rc.30-amd64",
-    "container_hash": "50dc072058d3b68a410493aca9537a3ac3451811a39c1c9833bddcff186f5023",
-    "git_hash": "fdfbeb9b81d54937afae35b152e83f0a7ef48135"
-  },
-  {
-    "date": "2023-02-01",
-    "version": "4.7.1-rc.31-amd64",
-    "container_hash": "3dd580aad03cef672336ff66cf9111e1e45ed169157a5c04db01bd7ed08796f1",
-    "git_hash": "2e1e430c547d6cd0a2dd83aef03976d1a40dcb57"
-  },
-  {
-    "date": "2023-02-01",
-    "version": "4.7.1-rc.30-arm64",
-    "container_hash": "06a2f0b94b9d9756c7950580fca1c8cfc51966e49f91c73411338b76fddbc521",
-    "git_hash": "fdfbeb9b81d54937afae35b152e83f0a7ef48135"
-  },
-  {
-    "date": "2023-02-01",
-    "version": "4.7.1-rc.31-arm64",
-    "container_hash": "b09277098a8d7bba0ec48d77c3de7340d1e31b70903d789f06366322d901394d",
-    "git_hash": "2e1e430c547d6cd0a2dd83aef03976d1a40dcb57"
-  },
-  {
-    "date": "2023-02-01",
-    "version": "4.7.1-rc.32-arm64",
-    "container_hash": "978ebd2a0e3eb2ff3c48224e3fda89798fb0c89582e0ecd0d1c2eeae866c3126",
-    "git_hash": "6ac67d1ec8afda34051c42743c1b56f51d74c067"
-  },
-  {
-    "date": "2023-02-02",
-    "version": "4.7.1-rc.32-amd64",
-    "container_hash": "9eaba3498fb825117fcc8aa27dc3cb745a63292b29af8349b62e8631a2cf4ee2",
-    "git_hash": "6ac67d1ec8afda34051c42743c1b56f51d74c067"
-  },
-  {
-    "date": "2023-02-02",
-    "version": "4.7.1-rc.33-arm64",
-    "container_hash": "ff21b19027818bb860de96fc82d950c6e3233aaa2ba8339230cfe857305cd0d1",
-    "git_hash": "c1ba47d83526b0448dceceab4e5313162745092f"
-  },
-  {
-    "date": "2023-02-02",
-    "version": "4.7.1-rc.33-amd64",
-    "container_hash": "073ba2e2495d866c39bc01abecb4d4a357ca8c9cfa1d574f96fc31546e2f2dc3",
-    "git_hash": "c1ba47d83526b0448dceceab4e5313162745092f"
-  },
-  {
-    "date": "2023-02-06",
-    "version": "4.7.1-rc.34-arm64",
-    "container_hash": "92d1ae98882aa65a871c071a3cc4dbceb79e0da17a2c2db0008c03e6eef03cf2",
-    "git_hash": "715d84a54c55a2cf68c2a193a4faabe9b32f2ec4"
-  },
-  {
-    "date": "2023-02-06",
-    "version": "4.7.1-rc.34-amd64",
-    "container_hash": "f3573a66ced56b7162de6fd29c2e9f6b73cf09b1a7f7b9cc8a4c72c2479adbb6",
-    "git_hash": "715d84a54c55a2cf68c2a193a4faabe9b32f2ec4"
-  },
-  {
     "date": "2023-02-07",
     "version": "4.2.0",
     "container_hash": "e7dd2eae3baca48867464e961d7b1f047aaf96fe50549119a96defc5a173f3f1",
@@ -5987,60 +3686,6 @@
     "git_hash": "72d876f29fe59707b35645055fab92d89957dc12"
   },
   {
-    "date": "2023-02-07",
-    "version": "4.7.1-rc.35-arm64",
-    "container_hash": "6969c37a82e6cfa1a38df123ffb0b62b366573d578224099e0481ef901fc61e6",
-    "git_hash": "847aa506eb522949308990d7d4fe59df3a4b26ff"
-  },
-  {
-    "date": "2023-02-07",
-    "version": "4.7.1-rc.35-amd64",
-    "container_hash": "0db9e034808d39356cf83c7155b7d10cef8eafa2a0486d7f699f2f51a83a005c",
-    "git_hash": "847aa506eb522949308990d7d4fe59df3a4b26ff"
-  },
-  {
-    "date": "2023-02-09",
-    "version": "4.7.1-rc.36-arm64",
-    "container_hash": "9e3762f5ffa5e6e502e46911d50d12bea45b022d9a8b005bbd74f4946ec61bbe",
-    "git_hash": "6507b19bb4c05645f2bd955b55f08874e96d1402"
-  },
-  {
-    "date": "2023-02-09",
-    "version": "4.7.1-rc.36-amd64",
-    "container_hash": "73fa955ececda93687f5d91e2e3aeb857c1e389204a0ab5b2ab3399d6ab597db",
-    "git_hash": "6507b19bb4c05645f2bd955b55f08874e96d1402"
-  },
-  {
-    "date": "2023-02-09",
-    "version": "4.7.1-rc.37-amd64",
-    "container_hash": "c8bc104c1a34f00d638a6fe64e450f14e0fb40a1a603be7c456a3d8c53a0d88e",
-    "git_hash": "f98eaff5219e461c74d896f974b6b0dcbfdcb112"
-  },
-  {
-    "date": "2023-02-09",
-    "version": "4.7.1-rc.37-arm64",
-    "container_hash": "56cb8fe15646082c266eef2fe7646f0193b2d18fd4cbf3f6723dcaeda9a38af0",
-    "git_hash": "f98eaff5219e461c74d896f974b6b0dcbfdcb112"
-  },
-  {
-    "date": "2023-02-11",
-    "version": "4.7.1-rc.38-amd64",
-    "container_hash": "8647b5d078452589578fd230df501bfdd210e8281eb56f8624e77d73950d8767",
-    "git_hash": "63221b8540734a5b8d7a845fd07128995b8e3d20"
-  },
-  {
-    "date": "2023-02-10",
-    "version": "4.7.1-rc.38-arm64",
-    "container_hash": "029a992c4d9ce7247dea60a86a66e7c96750cd955ab601e8b11dd55b6dba86ef",
-    "git_hash": "63221b8540734a5b8d7a845fd07128995b8e3d20"
-  },
-  {
-    "date": "2023-02-14",
-    "version": "4.7.1-rc.39-amd64",
-    "container_hash": "0ea667790e907dfc3acda0cebdb66d87cc75b906ec4bfe91bf1e1cc818828d78",
-    "git_hash": "5ac5f32c281cd34f53fee837cd216ff18cda7f90"
-  },
-  {
     "date": "2023-02-14",
     "version": "4.1.2",
     "container_hash": "285836d7ded6ffdae52246a115912ffa7462a8ca60c60616949dae8bb3be4567",
@@ -6114,12 +3759,6 @@
   },
   {
     "date": "2023-02-14",
-    "version": "4.7.1-rc.39-arm64",
-    "container_hash": "8d7eac3362d266d2169de53cce7e45fbbab9e71af998b00cedec2ce9dc5bdcaf",
-    "git_hash": "5ac5f32c281cd34f53fee837cd216ff18cda7f90"
-  },
-  {
-    "date": "2023-02-14",
     "version": "4.6.0-arm64",
     "container_hash": "c0b5e748d527eccf1df632adc9981e31e6a92a17f327de59b4abefac985db919",
     "git_hash": "4c89ac4d891b6c1f6416c2b99a76e8f6d6fe911a"
@@ -6141,18 +3780,6 @@
     "version": "4.7.0-arm64",
     "container_hash": "c038127d9bc1594faa34574cf1bc77beb2977842c80ae86265e9376d64df8e15",
     "git_hash": "d0d2766e9d3140c3a6f6c4740bce446f01301869"
-  },
-  {
-    "date": "2023-02-20",
-    "version": "4.7.1-rc.40-amd64",
-    "container_hash": "3e78870d38b4d84ca6db1e5c80bffa7ea2902c3bbc94713a58765e4fcfb35b91",
-    "git_hash": "0325e665123fdc0820364f99b594a82cf622af68"
-  },
-  {
-    "date": "2023-02-20",
-    "version": "4.7.1-rc.40-arm64",
-    "container_hash": "78bd495c6373e70c99b57d53acaf6b61f47dcb4e8c3b797df9d7f52539d730fb",
-    "git_hash": "0325e665123fdc0820364f99b594a82cf622af68"
   },
   {
     "date": "2023-02-21",
@@ -6251,30 +3878,6 @@
     "git_hash": "72d876f29fe59707b35645055fab92d89957dc12"
   },
   {
-    "date": "2023-02-23",
-    "version": "4.7.1-rc.41-arm64",
-    "container_hash": "0b4d577e3419b30abff8c5988dc1282204a370f5f94287d42a81a1afe2aacfd9",
-    "git_hash": "55f426c0303a966b9be75f5a5caa4bf1adac57fc"
-  },
-  {
-    "date": "2023-02-23",
-    "version": "4.7.1-rc.41-amd64",
-    "container_hash": "6618830245a7d189fb6a132ab33ee87db6f601c70feac079f71bfc22dcfb1236",
-    "git_hash": "55f426c0303a966b9be75f5a5caa4bf1adac57fc"
-  },
-  {
-    "date": "2023-02-27",
-    "version": "4.7.1-rc.42-arm64",
-    "container_hash": "2c863e7e230ea0c65505f3263a5ad9588c1de033da9c0bfac5f6513d863d6d31",
-    "git_hash": "b363b934782df9de935503006db2f8fe3a51da0b"
-  },
-  {
-    "date": "2023-02-27",
-    "version": "4.7.1-rc.42-amd64",
-    "container_hash": "49ca2784367566a0050c7e462213e016569d6196f302b1a7d903250a599ec218",
-    "git_hash": "b363b934782df9de935503006db2f8fe3a51da0b"
-  },
-  {
     "date": "2023-02-28",
     "version": "4.0.1",
     "container_hash": "5d729ea061c6ea4018a0ac983e5eb60899c97110557e3ce1dec0b8141d957b45",
@@ -6363,30 +3966,6 @@
     "version": "4.6.0-arm64",
     "container_hash": "6f563efb1b8b9cb0a7810f012de06c36d754249965d89068821068bd0632b1e7",
     "git_hash": "4c89ac4d891b6c1f6416c2b99a76e8f6d6fe911a"
-  },
-  {
-    "date": "2023-03-02",
-    "version": "4.7.1-rc.43-arm64",
-    "container_hash": "40d264f6b561ba09fe3d4d4faa3bc434eca2b2966ec8aff94fb32a9e9f70f2b4",
-    "git_hash": "ed60e5dfb84e9b5c5435341a2ee97b4d44962e53"
-  },
-  {
-    "date": "2023-03-02",
-    "version": "4.7.1-rc.43-amd64",
-    "container_hash": "9e6541c933be0b2db2c9e5ade8012e2281c0e49ce80d439f7e152609023ca6c5",
-    "git_hash": "ed60e5dfb84e9b5c5435341a2ee97b4d44962e53"
-  },
-  {
-    "date": "2023-03-03",
-    "version": "4.7.1-rc.44-amd64",
-    "container_hash": "5f131c20a8b867a4b6256b6565e44eb311d40588eb0531f66e157e49c298745a",
-    "git_hash": "faec4e5c4f80aebd2afef66a8fd371293ccb6458"
-  },
-  {
-    "date": "2023-03-03",
-    "version": "4.7.1-rc.44-arm64",
-    "container_hash": "1f87f0c63c1579ad90f678a9873396af83266ee33f75a097c0a6d44c47b12cc9",
-    "git_hash": "faec4e5c4f80aebd2afef66a8fd371293ccb6458"
   },
   {
     "date": "2023-03-07",
@@ -6479,66 +4058,6 @@
     "git_hash": "72d876f29fe59707b35645055fab92d89957dc12"
   },
   {
-    "date": "2023-03-13",
-    "version": "4.7.1-rc.47-amd64",
-    "container_hash": "c24f68f7ab108381469ef28a03049a97736b27a6e9ae478834c8b8249712613b",
-    "git_hash": "53d1326eea397d63f8f98e33e339d9fe3ef2dc99"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "4.7.1-rc.46-amd64",
-    "container_hash": "30ecb5d993efc0cd938e719f643435ad2be48e10eae818da745a34f26e7510ad",
-    "git_hash": "dbb4ce59ed25eb5ca9521ecc8b73d4cbcf8c5ee1"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "4.7.1-rc.45-amd64",
-    "container_hash": "56a75fa752a69338e97528006d44a440ccaa37f56e6f9af06f4dc3739e8f8dab",
-    "git_hash": "16bf3662152b41bba00ab87df954badca5b2c1d2"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "4.7.1-rc.48-amd64",
-    "container_hash": "447898222af70554dc5ca85650b16c4dc47ce8f9255d3e6f8dbd8bc71085e068",
-    "git_hash": "1ba0c2339e263f3b995109ec23df9c52bca54564"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "4.7.1-rc.45-arm64",
-    "container_hash": "83c4f24c4a8172337472aa5dc4baae2cc51104cc36bfa742fd02d8984b3e04fb",
-    "git_hash": "16bf3662152b41bba00ab87df954badca5b2c1d2"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "4.7.1-rc.46-arm64",
-    "container_hash": "fa827d00abdbac7367bac0dea52f1f82d10231af7e3c10773d139b61d6c9cf72",
-    "git_hash": "dbb4ce59ed25eb5ca9521ecc8b73d4cbcf8c5ee1"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "4.7.1-rc.47-arm64",
-    "container_hash": "f2eaff42dc4faa609e91ee1235bafe4914a2721941c4ed0762bb704c4197da30",
-    "git_hash": "53d1326eea397d63f8f98e33e339d9fe3ef2dc99"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "4.7.1-rc.48-arm64",
-    "container_hash": "6db4a15a69d96359987702f8366b59952d1633f410e49d13d068561468425fe7",
-    "git_hash": "1ba0c2339e263f3b995109ec23df9c52bca54564"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "4.7.1-rc.49-amd64",
-    "container_hash": "cece0014f9ec623dcc4eb4ad1d41f1758018a77c48a88c4824d0662195fde7ad",
-    "git_hash": "6da6255a4582bb168d1da9d05be1ac9e5fdd2f55"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "4.7.1-rc.49-arm64",
-    "container_hash": "4f1e725829d421da6d066d1bd3d91d4551ba39192807144dfe0857bab3532969",
-    "git_hash": "6da6255a4582bb168d1da9d05be1ac9e5fdd2f55"
-  },
-  {
     "date": "2023-03-14",
     "version": "4.1.0",
     "container_hash": "64ab08e4a5d6cfc6bbd12ebb313a1d1b61146c7ad332801fce1ec2ca5b999b91",
@@ -6621,30 +4140,6 @@
     "version": "4.5.0-arm64",
     "container_hash": "6c369f26d7bb7211ce40be1208caabde016f1c32687f579ba67e734131355018",
     "git_hash": "72d876f29fe59707b35645055fab92d89957dc12"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "4.7.1-rc.50-amd64",
-    "container_hash": "8c74778a270a53f058ae20381a9779e7dd0016e4a5a362c07de35da5f2a7fa3a",
-    "git_hash": "02712ca498a9f26a6efc921b3e78106e030a6e0b"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "4.7.1-rc.50-arm64",
-    "container_hash": "5841237a46a391fffb04e02722143f44ef2efea6b97897cb8cd650100c9d2e44",
-    "git_hash": "02712ca498a9f26a6efc921b3e78106e030a6e0b"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "4.7.1-rc.51-amd64",
-    "container_hash": "cfa17ddc0d24c0971c4ddf8acd45a20efdcd70ccfba2ac807b6cde8b5dc6efc0",
-    "git_hash": "f6143f60985ce6032fd16a38d2f4d36143f200b9"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "4.7.1-rc.51-arm64",
-    "container_hash": "d4b6e8d1d9edde5069c43896ecbb1e9f68e7ed080f5190a73be7f5770ac59e8c",
-    "git_hash": "f6143f60985ce6032fd16a38d2f4d36143f200b9"
   },
   {
     "date": "2023-03-21",
@@ -6753,78 +4248,6 @@
     "version": "4.5.0-arm64",
     "container_hash": "6c369f26d7bb7211ce40be1208caabde016f1c32687f579ba67e734131355018",
     "git_hash": "72d876f29fe59707b35645055fab92d89957dc12"
-  },
-  {
-    "date": "2023-03-22",
-    "version": "4.8.1-rc.0-amd64",
-    "container_hash": "86e2c23bce5d774f8e8e94cacc070b5d6df321c7b0b6e200221bd4777812cc7c",
-    "git_hash": "f982631c67d6e48546c4d9cce894b7036eb9803e"
-  },
-  {
-    "date": "2023-03-22",
-    "version": "4.8.1-rc.0-arm64",
-    "container_hash": "3dccd92b2a2a10ba07332f2bf26e95e31ae95855e71d7d20fffd1991efe78d6a",
-    "git_hash": "f982631c67d6e48546c4d9cce894b7036eb9803e"
-  },
-  {
-    "date": "2023-03-27",
-    "version": "4.8.1-rc.1-amd64",
-    "container_hash": "7ec0bd451ac57513245c33f2ce89fa81da7aa3edb846356cb1f1c1ef22545fe9",
-    "git_hash": "34744edc342f849f0969f2288b36708ae6e6a302"
-  },
-  {
-    "date": "2023-03-27",
-    "version": "4.8.1-rc.1-arm64",
-    "container_hash": "f7aac674bb9bb22e178f1a9c66fc09c5d828e49a052fc0f5ba9c1a806a4caddd",
-    "git_hash": "34744edc342f849f0969f2288b36708ae6e6a302"
-  },
-  {
-    "date": "2023-03-28",
-    "version": "4.8.1-rc.2-amd64",
-    "container_hash": "00923224b708db63e7ef815a2ec921dee4792a81f5b0c954bb006eb459feb8d3",
-    "git_hash": "717942523ac0ea95fc2ee48b622b53af1541b031"
-  },
-  {
-    "date": "2023-03-28",
-    "version": "4.8.1-rc.2-arm64",
-    "container_hash": "4908eaba3697de6a90c4f019237415a41be453d168dc783db315aa9dae78dedc",
-    "git_hash": "717942523ac0ea95fc2ee48b622b53af1541b031"
-  },
-  {
-    "date": "2023-03-28",
-    "version": "4.8.1-rc.3-arm64",
-    "container_hash": "af7cac54c4286550e4ec0926ba30a680d3888184bb09362c65bd8a70ba817dcf",
-    "git_hash": "94f4e36897fcedb2bc0f626772d3a05da58e9b86"
-  },
-  {
-    "date": "2023-03-28",
-    "version": "4.8.1-rc.3-amd64",
-    "container_hash": "380bfac102a43bc42595f4c755e8c51f876c178d30af22ad3969fea2a6cbe886",
-    "git_hash": "94f4e36897fcedb2bc0f626772d3a05da58e9b86"
-  },
-  {
-    "date": "2023-03-31",
-    "version": "4.8.1-rc.4-amd64",
-    "container_hash": "5005ca9bebda5aea0eeff4c399ad7467441aa1e7dbf542a251ed6c08cec03427",
-    "git_hash": "e9d5f6e155989784a7c803362fb054005897dea6"
-  },
-  {
-    "date": "2023-03-31",
-    "version": "4.8.1-rc.4-arm64",
-    "container_hash": "06f6bdc9991f8d05c60c2bc2b2882e30c4696a41463183e3233658e747531906",
-    "git_hash": "e9d5f6e155989784a7c803362fb054005897dea6"
-  },
-  {
-    "date": "2023-04-03",
-    "version": "4.8.1-rc.5-amd64",
-    "container_hash": "f2ecddc43b64bdbf2fc9445fc31c9f315391c1103ab1c7fb4db09357629b4ab4",
-    "git_hash": "95cf5a14e78283ec185a1adac071351033d6144a"
-  },
-  {
-    "date": "2023-04-03",
-    "version": "4.8.1-rc.5-arm64",
-    "container_hash": "222116e5252cafb6bd14d5f12cdd1b30360a4223b30dbec6c378b7d9fc9fb311",
-    "git_hash": "95cf5a14e78283ec185a1adac071351033d6144a"
   },
   {
     "date": "2023-04-04",
@@ -7019,18 +4442,6 @@
     "git_hash": "d0d2766e9d3140c3a6f6c4740bce446f01301869"
   },
   {
-    "date": "2023-04-12",
-    "version": "4.8.1-rc.6-amd64",
-    "container_hash": "1f371762b10527749ff01bf5cfb2bd5c17ade37d71da8b491110a5bff660e8f9",
-    "git_hash": "2f6003b8930a365822f52702ca0de492f7b1a403"
-  },
-  {
-    "date": "2023-04-12",
-    "version": "4.8.1-rc.6-arm64",
-    "container_hash": "2d5306c02c4bae1b425dac500cab0d94a3f2ad2942000fa1189cb4cdb0fa26c9",
-    "git_hash": "2f6003b8930a365822f52702ca0de492f7b1a403"
-  },
-  {
     "date": "2023-04-13",
     "version": "4.9.0-amd64",
     "container_hash": "15e26ccb460f8b1973cc83a1be9b80075422c8be98de5de1655c6dafe9dbd6ea",
@@ -7133,30 +4544,6 @@
     "git_hash": "72d876f29fe59707b35645055fab92d89957dc12"
   },
   {
-    "date": "2023-04-19",
-    "version": "4.10.0-rc.0-amd64",
-    "container_hash": "064bc8171738786d55f54cebbba4bf83f1bbb8b94f568ec50e5f04e61af9c94d",
-    "git_hash": "dd3d775bfe24417536fe20e3b5018b8238475705"
-  },
-  {
-    "date": "2023-04-19",
-    "version": "4.10.0-rc.0-arm64",
-    "container_hash": "c854f0564f0991605b2e2953a556c7260974ae336bfbf4186ae6b0d069866efe",
-    "git_hash": "dd3d775bfe24417536fe20e3b5018b8238475705"
-  },
-  {
-    "date": "2023-04-20",
-    "version": "4.10.0-rc.1-amd64",
-    "container_hash": "ca510f83a355991b89797175c8f45b80016083f782c78cc1acee84064419f4b9",
-    "git_hash": "d55a4faf4c2306c0bf59bf90d7c7de9569ec7cf0"
-  },
-  {
-    "date": "2023-04-20",
-    "version": "4.10.0-rc.1-arm64",
-    "container_hash": "2e31a7d6c50220e1ab64e8afcfed7f3de11bb1563ee029a5352f18ae4523e2f8",
-    "git_hash": "d55a4faf4c2306c0bf59bf90d7c7de9569ec7cf0"
-  },
-  {
     "date": "2023-05-05",
     "version": "4.10.0-amd64",
     "container_hash": "7db1b4367876fa3272884c2440c28f3abdc57b439f30fb5ce027cd265f077958",
@@ -7167,78 +4554,6 @@
     "version": "4.10.0-arm64",
     "container_hash": "d5dfef8f8e72e0dd4aa6d70669e81b3df7c76b40336868102d70afbbaad5f5ed",
     "git_hash": "60e8575bbc9e7b606f62d6e727eb9e5c1e8cc01f"
-  },
-  {
-    "date": "2023-05-19",
-    "version": "4.10.1-rc.0-amd64",
-    "container_hash": "21293530ebc82cec53a13cf11c10a40ef0d07102ff0d5504d2a8dbe48f9f0a81",
-    "git_hash": "0a89a53660059f78c7e091dabfb80fd05aa7ecbd"
-  },
-  {
-    "date": "2023-05-19",
-    "version": "4.10.1-rc.0-arm64",
-    "container_hash": "ebbc493de5b67893e5acea48f685711e5323106c9fa9c0919a6435bfce7ac271",
-    "git_hash": "0a89a53660059f78c7e091dabfb80fd05aa7ecbd"
-  },
-  {
-    "date": "2023-05-24",
-    "version": "4.10.1-rc.1-amd64",
-    "container_hash": "f983fc76d7ea17cdfbda56f879d9336dbc028a8ccdd659eff5c903e0093efdda",
-    "git_hash": "657bd838dfed117dd969aea8f95b58e4e939366a"
-  },
-  {
-    "date": "2023-05-24",
-    "version": "4.10.1-rc.1-arm64",
-    "container_hash": "bf90741ecc1242f935c33f49798eed4c00696ee1dfc6532a83891e73fdd2cbd4",
-    "git_hash": "657bd838dfed117dd969aea8f95b58e4e939366a"
-  },
-  {
-    "date": "2023-05-26",
-    "version": "4.10.1-rc.2-amd64",
-    "container_hash": "d2e93fd8e85709aa25ae9ee32a3cf1ef6f1f85bf66d3501d511c979caf2f7e67",
-    "git_hash": "d4a4e6d436baa6727cde879aa83125ce9e064d6f"
-  },
-  {
-    "date": "2023-05-26",
-    "version": "4.10.1-rc.2-arm64",
-    "container_hash": "a39059d6ec22d8533b2a2f4a5e8c267c5d8cc9905316e7c2c3635b1c26954d78",
-    "git_hash": "d4a4e6d436baa6727cde879aa83125ce9e064d6f"
-  },
-  {
-    "date": "2023-05-26",
-    "version": "4.10.1-rc.3-amd64",
-    "container_hash": "88a0b3b3d6fcf33e7fd8fb110ae54f59f672cd2bb88f464cc031a2556826d521",
-    "git_hash": "dceaf928fce7e4e9e78803fbcfc7c4541c5e0424"
-  },
-  {
-    "date": "2023-05-26",
-    "version": "4.10.1-rc.3-arm64",
-    "container_hash": "3d2be8852ffbffe340df65226b443245a0f544ed18b3cd9b9358681f9bcce9f2",
-    "git_hash": "dceaf928fce7e4e9e78803fbcfc7c4541c5e0424"
-  },
-  {
-    "date": "2023-06-08",
-    "version": "4.10.1-rc.4-amd64",
-    "container_hash": "8971f12e56633786f540377a5cca6a4d6c929f5d38c1a15d62d15f83554845bb",
-    "git_hash": "88791694d7b61d3ef8895cef1eeceb445ca006bb"
-  },
-  {
-    "date": "2023-06-08",
-    "version": "4.10.1-rc.4-arm64",
-    "container_hash": "5e55f16735ea20438f25ff92ee17df52e43651f36ab216b10f8b99b239d8e49a",
-    "git_hash": "88791694d7b61d3ef8895cef1eeceb445ca006bb"
-  },
-  {
-    "date": "2023-07-05",
-    "version": "4.10.1-rc.5-amd64",
-    "container_hash": "8bdeabc78c44ca75394430b917152675cb1db4101a13d67e5963b554de2567e7",
-    "git_hash": "deb6ac7f9cb9ae75ad9cf534a6fab8b4e088093a"
-  },
-  {
-    "date": "2023-07-05",
-    "version": "4.10.1-rc.5-arm64",
-    "container_hash": "142e57f33ebe0b36e4d333cb989f8db562e46f2e48f3409561fae21a6ca3a53c",
-    "git_hash": "deb6ac7f9cb9ae75ad9cf534a6fab8b4e088093a"
   },
   {
     "date": "2023-07-17",
@@ -7254,30 +4569,6 @@
   },
   {
     "date": "2023-07-18",
-    "version": "4.11.1-rc.0-amd64",
-    "container_hash": "f14b0c3f6d397e977d123cae97e1a6b1785367355563cf004476dd8a97113c61",
-    "git_hash": "f678b827aed71d3cc941910b9cf231401740a849"
-  },
-  {
-    "date": "2023-07-18",
-    "version": "4.11.1-rc.0-arm64",
-    "container_hash": "8a01eca06dbbcf72943afa6a395dd3a7b9af0915adb92aa2454928088afd1019",
-    "git_hash": "f678b827aed71d3cc941910b9cf231401740a849"
-  },
-  {
-    "date": "2023-07-18",
-    "version": "4.11.1-rc.1-amd64",
-    "container_hash": "f1013031895755c942ba26d306c2612c2fd264312938e8477e11baedf6277a1d",
-    "git_hash": "9e8586839198f5d921ab4ceeb67ce88dd654c668"
-  },
-  {
-    "date": "2023-07-18",
-    "version": "4.11.1-rc.1-arm64",
-    "container_hash": "d379dd85ea9c8e17822fc8e5c29e5f7474dd870a5cdd12b86d650fbf09aeeaa8",
-    "git_hash": "9e8586839198f5d921ab4ceeb67ce88dd654c668"
-  },
-  {
-    "date": "2023-07-18",
     "version": "4.11.1-amd64",
     "container_hash": "8dc5d5cda137418bb941b13b092a5729a95b60f6e15ec3bc761ed071b6e46ce2",
     "git_hash": "885d6292e38a660e0e9d1cbda6edae9f8a73fff3"
@@ -7287,42 +4578,6 @@
     "version": "4.11.1-arm64",
     "container_hash": "4160574eb775cb2f99086d2dc52802cf5d59d353bc97aea1e813c298fa86023b",
     "git_hash": "885d6292e38a660e0e9d1cbda6edae9f8a73fff3"
-  },
-  {
-    "date": "2023-08-07",
-    "version": "4.11.2-rc.0-amd64",
-    "container_hash": "c8d7b43cfb5d743ddc1f984e233b5b25a16d96d1cc8d58e65e1434d9e9678d6f",
-    "git_hash": "70542a44b6d786cef9f2513b30f5f1a47be89484"
-  },
-  {
-    "date": "2023-08-07",
-    "version": "4.11.2-rc.0-arm64",
-    "container_hash": "e4e0ae30dbd46ba3c41db325a783babc28ff89b53fcf05b656b6753ddb1ccdc5",
-    "git_hash": "70542a44b6d786cef9f2513b30f5f1a47be89484"
-  },
-  {
-    "date": "2023-08-16",
-    "version": "4.11.2-rc.1-amd64",
-    "container_hash": "4c2f6ad70af115533f0abbcc8ca574cab75a443ac1af99f23717bab0d145d055",
-    "git_hash": "71744925a8deb89e184b71592533d6fe09898608"
-  },
-  {
-    "date": "2023-08-16",
-    "version": "4.11.2-rc.1-arm64",
-    "container_hash": "f7bb7a914aa969bc35a5605aebac2ed9472ac94de765afda0de0c820aba92a20",
-    "git_hash": "71744925a8deb89e184b71592533d6fe09898608"
-  },
-  {
-    "date": "2023-08-17",
-    "version": "4.11.2-rc.2-amd64",
-    "container_hash": "15e1eb91cee5552b6c69a0e263861cd53777a182e2a770230c9290e218160983",
-    "git_hash": "291a228acba3fbeebf37bd45464d9b6e8d7b4cdf"
-  },
-  {
-    "date": "2023-08-17",
-    "version": "4.11.2-rc.2-arm64",
-    "container_hash": "30a54d70e4ac1f37cc15cb1138839f342769b6310406a32729915f1dab4397f2",
-    "git_hash": "291a228acba3fbeebf37bd45464d9b6e8d7b4cdf"
   },
   {
     "date": "2023-11-16",

--- a/vendor-bridge.json
+++ b/vendor-bridge.json
@@ -1,408 +1,8 @@
 [
   {
-    "version": "0.1.1-pre",
-    "container_hash": "96f2614a4dd7e5ca3b29f690a49ab249b562a931537568d53a0cfe0c78f9365a",
-    "git_hash": "d49994f0d4027e3ed6f269e6242902b004adf04d"
-  },
-  {
-    "version": "0.1.1-pre",
-    "container_hash": "b5953c9a44cdf889ab167240ad56519039942856018e90360d3bda5a755fceae",
-    "git_hash": "bb7a73893a3dfd284331ec47af27542f133cef6e"
-  },
-  {
-    "version": "0.1.1-pre.10",
-    "container_hash": "26be0a3ebae6dcf7f957756673d8826a40e096a51b3491a40224d04b8d87cd10",
-    "git_hash": "41e759f3ad8597ec22cbf3d4f48eb328b1b6b4d8"
-  },
-  {
-    "version": "0.1.1-pre.11",
-    "container_hash": "a4d032da38b59bfbe120f8eab80c8cbce29f124f53edd139597fd794a8d0670c",
-    "git_hash": "5efeb9d8ca0eff5d15b2876c97101b57377f1648"
-  },
-  {
-    "version": "0.1.1-pre.12",
-    "container_hash": "8904818d26a26732ca5a1469ab8a918b308ce012cc110e5591e182f9d5a361fd",
-    "git_hash": "28726e936f4be45a31ca3cdfe1eccc65659aa5d7"
-  },
-  {
-    "version": "0.1.1-pre.13",
-    "container_hash": "9b2fd9d5f795fe71882fb006a11772e0132a69f6748ca8a4ad8c3bd7f07cf492",
-    "git_hash": "f3c2d7f032b6e6626b0354fc55fd4f778819ec38"
-  },
-  {
-    "version": "0.1.1-pre.14",
-    "container_hash": "256d0d28fd715f4ef17e3e9f1f061bfd8334b8cd5f0e8b9685d50d0f8834d6e3",
-    "git_hash": "e6cb681471b3162b7a02d49aff270e835d96bdc3"
-  },
-  {
-    "version": "0.1.1-pre.15",
-    "container_hash": "36efe25eb281b92d05c2f2dd7f6dde7034f4d6e142d63d3e29f5d9a7478bd25a",
-    "git_hash": "705d9ebca425b846f5a54d180e3b0972aed17dc3"
-  },
-  {
-    "version": "0.1.1-pre.15",
-    "container_hash": "97f795c5f779a03457841080ef8ad20ed644ae102931f0916f37e712f86e24fa",
-    "git_hash": "4603149e1e5ab469b5f5043403188c61537ced29"
-  },
-  {
-    "version": "0.1.1-pre.16",
-    "container_hash": "53c2212a31c478c92499678dffb7a487ef1efaddcf6b7f472f262cf8cfc0323f",
-    "git_hash": "8d9052ed7f479f216e282cc00160e75e5a2300ca"
-  },
-  {
-    "version": "0.1.1-pre.17",
-    "container_hash": "701937ae8401f09c0c81ae4ae127729919eff58a5f18ae9157e3684cb2be873d",
-    "git_hash": "d5f02d968275f8c2fca29821048f1bdd6514d7c3"
-  },
-  {
-    "version": "0.1.1-pre.18",
-    "container_hash": "c90f7c669ab7c0e51dad6ab140ef709cb32f06730bc6df9bf1e7c7f4df2c2946",
-    "git_hash": "aed6131f8a9299071bd75988e87c594fbd53acd7"
-  },
-  {
-    "version": "0.1.1-pre.19",
-    "container_hash": "f7e1f2fc2216f40a0e460ff12fb54701ec4e31ca7b084797f2b480944fb9b6bf",
-    "git_hash": "a6d67e19329d492d8556bf1210779b8e204bb163"
-  },
-  {
-    "version": "0.1.1-pre.2",
-    "container_hash": "33d55379ab848de60bbf3bda167009650f4cea373513a3d6f589dffe84b44429",
-    "git_hash": "2c13cb2874bd9c5924807faed30c916beb1dc96e"
-  },
-  {
-    "version": "0.1.1-pre.3",
-    "container_hash": "0d8c14660ed3fb095d2f952574f1e543cc510aeb6474aab1670c4c710654c7bb",
-    "git_hash": "0468e1de2a01f34bda41e52f9c75bd24a3f512c1"
-  },
-  {
-    "version": "0.1.1-pre.4",
-    "container_hash": "33e8316178abf2df4fb4e11c6b5754dd2963ceac35d6fe01a824a124a4d1aea5",
-    "git_hash": "6f1725e5fc551be25e35f80467fd367b2130411c"
-  },
-  {
-    "version": "0.1.1-pre.5",
-    "container_hash": "04b957d30aacad427d6d77cf93baf7a7cd4a0a228eb254863f7d7b1bbe0d0625",
-    "git_hash": "5d4219fd63f2b1e4405acf46b558fb2219023244"
-  },
-  {
-    "version": "0.1.1-pre.5",
-    "container_hash": "3c266f22a9724172777d707fa747f9bacc207d1a25acc291e27d030366634b0b",
-    "git_hash": "d7ef524905e069ecb9ffb6a4ddf9a7746410f55b"
-  },
-  {
-    "version": "0.1.1-pre.5",
-    "container_hash": "7726433f6950e97a080cb86c0e115372f5c2234858a0f78fa7cf46c928b10d3e",
-    "git_hash": "0db70ec00b3dcd1cbc5bb55d46ee7753db9c106f"
-  },
-  {
-    "version": "0.1.1-pre.5",
-    "container_hash": "79027b7ae13c14eb978206c43247354a31846cbdec385d338dd9764ac352e15f",
-    "git_hash": "13f930288c93605ad2212bea6e8fe01130532f88"
-  },
-  {
-    "version": "0.1.1-pre.5",
-    "container_hash": "8188f67ef56b7b624fa2347c7d6f0a551e7ffa5b5047b46a9e9163f7f52e5455",
-    "git_hash": "0b411949fa9efcd26d81d16f13d7a26509fff69c"
-  },
-  {
-    "version": "0.1.1-pre.5",
-    "container_hash": "835492785a0d3cdc50185db9ec243cca72145b9ede739416dcf0fe59da9527c0",
-    "git_hash": "212144a5b3d2c4de985be210d72c9b67a25c5a32"
-  },
-  {
-    "version": "0.1.1-pre.5",
-    "container_hash": "aa55a389ea60577ba97cd0f0406f7bfb18386fc4b5e906a76c170302b8272efb",
-    "git_hash": "f38023ed8e4813509ccef28bd57ef3af66fa4dac"
-  },
-  {
-    "version": "0.1.1-pre.5",
-    "container_hash": "bc8e5fdecea742f0c1ff70a848e0f5414e15405ed578f9a68be73a7d63d0834b",
-    "git_hash": "fa017c664b161b602a54885e42884657b830a6c6"
-  },
-  {
-    "version": "0.1.1-pre.5",
-    "container_hash": "e24748caed5b20f802ac9f00bb8b5a390ca5214576f89435fce22d696342e2a8",
-    "git_hash": "6f151d689c7cae2c6553bf06611f08616bde627c"
-  },
-  {
-    "version": "0.1.1-pre.6",
-    "container_hash": "d5187d8e8a01d7976772489f3cb1f8e0a071b8479107422079c0ac427282227f",
-    "git_hash": "3a8b349a673abb5f3edac3abc312fd9435523d8b"
-  },
-  {
-    "version": "0.1.1-pre.7",
-    "container_hash": "98b8354b693b26bc661d789d1325f1fa714060aa0981186d818f849c044ad117",
-    "git_hash": "ca6b40254a5e6dbdba09a739acb510e322694e23"
-  },
-  {
-    "version": "0.1.1-pre.7",
-    "container_hash": "cadbbff971020c861a3252009609de1dc63c2527560bff12ba5d1c22bded9768",
-    "git_hash": "735d6519022f01809e9d42b0374a61a5f0c27e38"
-  },
-  {
-    "version": "0.1.1-pre.8",
-    "container_hash": "67883173c4650d14a9cf86b35ad2510b963af6adb3738af4100fd2f2f220798e",
-    "git_hash": "e0fea15ee78ee643e69c3706e2221ea667566723"
-  },
-  {
-    "version": "0.1.1-pre.9",
-    "container_hash": "9f82ff18960b29d97b503f1ecb2c304b59bc7ceb9179532ee45b3370e7b22208",
-    "git_hash": "cdf1e5a423a784ef47d37404c53157564d19e5ba"
-  },
-  {
     "version": "0.2.0",
     "container_hash": "006531a98b3f43becd864201e4d71e6e72fa130cbf665ebf051f54ed451d7920",
     "git_hash": "f226cfddf1d0cfa6b766096fc73e5cd8ef9bf682"
-  },
-  {
-    "version": "0.2.1-rc.1",
-    "container_hash": "3379077261d94ef34de5e055a78c21bdc22bf81d6bc622925afe58109eb95810",
-    "git_hash": "fb9a59fa8113e4e1203ebcd829948b31ec1804c7"
-  },
-  {
-    "version": "0.2.1-rc.10",
-    "container_hash": "41c9937198bcee1a813fc5372cebda5d49001b1b1b7968644f83c726e7cda6e4",
-    "git_hash": "14ef3e556ea92513f8a25d99f46b97fbba9c53aa"
-  },
-  {
-    "version": "0.2.1-rc.11",
-    "container_hash": "1204d3b6383a2a953d13e704b89f34de1747095276a60be32a42a45d25d51e23",
-    "git_hash": "1fef6489f3ad924c8b78caab3caa7bd287146c70"
-  },
-  {
-    "version": "0.2.1-rc.12",
-    "container_hash": "c1033406a687430a64c88c7982ef9cf08dfc6c4f17da4010b8eeb4fac489741f",
-    "git_hash": "b94e79dc05c544d70ad13402ba6e9c6e501e77ea"
-  },
-  {
-    "version": "0.2.1-rc.13",
-    "container_hash": "b0bd286127399d812851a7133096aa521b2acdbce8a2c24328250fc14ce6e39a",
-    "git_hash": "c6378ea35d7acb442cbd00753146376fc793e43d"
-  },
-  {
-    "version": "0.2.1-rc.14",
-    "container_hash": "c22ea7f0532a5d9175006c2147d6abf0858c6a80fb3a52a05df3f1a5e642846a",
-    "git_hash": "158109fbeec2cc11545f3a39b19c543c1f845577"
-  },
-  {
-    "version": "0.2.1-rc.15",
-    "container_hash": "79dab0dd253cf6290a1bb13d3491fbd3dbf847ca1e2422f87abbb1f9d677bab6",
-    "git_hash": "738abdebb048c6d086df5d8869e11eaada44e9b7"
-  },
-  {
-    "version": "0.2.1-rc.16",
-    "container_hash": "1670468f32d1f6122db45a0a28c86b7157c9064cab613019bf39ce59602bf9a4",
-    "git_hash": "5155f42a64493c4a4043852acee6dd2d0285f1cd"
-  },
-  {
-    "version": "0.2.1-rc.17",
-    "container_hash": "1f195e27f01693c3403910d5e7d4d776a5859b63f5b9f452dddc84ae6aa83807",
-    "git_hash": "00a1c4e36d868411cc83954cc16c0c8974ac62e9"
-  },
-  {
-    "version": "0.2.1-rc.18",
-    "container_hash": "ebedde152f2341abba8c7816abd2e783f5d2d20232f769466fba8a2db73288da",
-    "git_hash": "7ea4058829fb87f3376904746e595e23cb082db1"
-  },
-  {
-    "version": "0.2.1-rc.19",
-    "container_hash": "55a2ece9a8cba45bef13d3803725bc48a60f8c0f3df209796d18fa30f3774da8",
-    "git_hash": "d4b58af2e426ddabaa0660e50654fb1bf6122a98"
-  },
-  {
-    "version": "0.2.1-rc.2",
-    "container_hash": "307c276250155d5e96d9c77b46a6ce40f4d32d7995e9f29354830ee2782f24d2",
-    "git_hash": "99f6d207a920b3b5db563d6ff3f0bd8647395c88"
-  },
-  {
-    "version": "0.2.1-rc.20",
-    "container_hash": "0527e7e0a8daa1e52cfcfeebe5bf60601a4f8dbae225698a7cf40f01d9ba1554",
-    "git_hash": "1f421d4bc81619d278882f31f3b2f2fb12712c8f"
-  },
-  {
-    "version": "0.2.1-rc.3",
-    "container_hash": "4ec459136e6c516cb9c032e2c3eecc975c79706d21b2343d58056fa1ff7318b3",
-    "git_hash": "44992b0db1f1353a740d08411899371ef0bf47e2"
-  },
-  {
-    "version": "0.2.1-rc.4",
-    "container_hash": "d524de2b970f2e32b216f90619334a0b3e92b111dd695f5eba39801a16635354",
-    "git_hash": "8eece03bf5fe4222e3607e58d14986cacd5c07b5"
-  },
-  {
-    "version": "0.2.1-rc.5",
-    "container_hash": "40626902e8ec0415436916827e1ba420ccd5df63aba70ef3e5b5fe2c05670802",
-    "git_hash": "e8548c4e84e2040bdb262f6814071581234ae1d8"
-  },
-  {
-    "version": "0.2.1-rc.6",
-    "container_hash": "9d3afd500faaad18cd56ed553ac33fff2a6cb533530a10916df3d2ee33bed252",
-    "git_hash": "d38e0932d41fd17343e70da9542d8a0e27e1aa8e"
-  },
-  {
-    "version": "0.2.1-rc.7",
-    "container_hash": "427d38ea9f750eca8623854fd12c0074438a30f84a9be865a77c097279b7e965",
-    "git_hash": "7f80b890ab435e92f4d234a5e76c0ba4566486bd"
-  },
-  {
-    "version": "0.2.1-rc.8",
-    "container_hash": "1e914a258e12f11e40271646eb2f6914791ccff664d860725c38efd6bf0962e6",
-    "git_hash": "961643655bbec930207b581562689ee1879d63bb"
-  },
-  {
-    "version": "0.2.1-rc.9",
-    "container_hash": "617cbf74f806e4a948b11e7e73ab884d3ce76826d3f8ffb0a17de0bc1e4dd3d6",
-    "git_hash": "1dd3957b823887af7bd1245b56609faf1bbcec04"
-  },
-  {
-    "date": "2022-04-08",
-    "version": "0.2.1-rc.21",
-    "container_hash": "ac70311f521d3140ffd3d856b17e5733f4306c002e99dd10792b912a394b1af1",
-    "git_hash": "2f22589260c2cac809b117563385391116482977"
-  },
-  {
-    "date": "2022-04-08",
-    "version": "pr-135-Add-rebuild-workflow-and-update",
-    "container_hash": "e72b27f71a9155ba0708d9757b50786335c851119a41e19d8706cd8d19e176f6",
-    "git_hash": "d25e109a1dc466308f00ff4169a8226116f84e3a"
-  },
-  {
-    "date": "2022-04-14",
-    "version": "0.2.1-rc.22",
-    "container_hash": "3ed8c0c4ae3ae68d6ea3a5532e453389affd20de0bb5d826d2fef0275620cc16",
-    "git_hash": "fbe2dffe85c541a004c26d29bcf91c3cf9b0547e"
-  },
-  {
-    "date": "2022-04-14",
-    "version": "0.2.1-rc.23",
-    "container_hash": "fcacbecb9c4ba7e9b92d3b70f48a3fe6ea617f0bb02fae87ec6cd6082a39cc33",
-    "git_hash": "4347f0c4cea54cb9616fe2fa537e3562d3681fe4"
-  },
-  {
-    "date": "2022-04-14",
-    "version": "0.2.1-rc.24",
-    "container_hash": "cf43d24bfad48da7f5551448f4b970028ae8b0f47ec3558d53ff7396989d8bed",
-    "git_hash": "ddfc22116ef67c7292ff1aeee12de1bb849f0149"
-  },
-  {
-    "date": "2022-04-14",
-    "version": "0.2.1-rc.25",
-    "container_hash": "49a68c10b382d80eca89fc06dab851f5ff4e9b7f1e4def39734393494c92faa3",
-    "git_hash": "2531a899a180e26430c4aa6103ce02dab7007474"
-  },
-  {
-    "date": "2022-04-15",
-    "version": "0.2.1-rc.26",
-    "container_hash": "3e736eb85806160ca8fc14232a5d751b165fb033f57690f1b09ffa67d538b13b",
-    "git_hash": "3fcbe347fe7c8fb5d346682446add2ca242dd935"
-  },
-  {
-    "date": "2022-04-18",
-    "version": "0.2.1-rc.27",
-    "container_hash": "a25adf5324b10264cdccb7376ea688871d88f506e256c79483f250bd3cf8a765",
-    "git_hash": "34792b380c00b5db73604433a2300562cbce250f"
-  },
-  {
-    "date": "2022-04-18",
-    "version": "0.2.1-rc.28",
-    "container_hash": "e40feb322fb88e7ff0110301c1900999de0b13eef2eba87c7d0e172fe2b9f735",
-    "git_hash": "15e47fd1c86f875d9dfed7c0cf80c865e770bc84"
-  },
-  {
-    "date": "2022-04-18",
-    "version": "0.2.1-rc.29",
-    "container_hash": "54d4fde78b296cd4d43e8f2a348128e54818de087655bddd887015cdf6f4e370",
-    "git_hash": "4fed47b440c2f42fc35e69c3d17bf90d6c00f510"
-  },
-  {
-    "date": "2022-04-19",
-    "version": "0.2.1-rc.30",
-    "container_hash": "a3f1c20d3c2f3499f29cff1bada7f08bb53f4766256908c0f3e9cfbfc265531e",
-    "git_hash": "3b2f7236bd868d7f229fb6e7f6e21ccec7048fb7"
-  },
-  {
-    "date": "2022-04-21",
-    "version": "0.2.1-rc.31",
-    "container_hash": "fca9bb3ee5a73ab15ea98925b63ba3abd355ac4d1af33b771f2f08dee60b10e6",
-    "git_hash": "e59253ed0fbf447dae59569d9d0e743ae38192ab"
-  },
-  {
-    "date": "2022-04-21",
-    "version": "0.2.1-rc.32",
-    "container_hash": "eb7ebc8b7c15b82ea35debab1ecdb52a8c51574bfd8b162df3e4e133e576ecb3",
-    "git_hash": "e2b55a05286f69461718f5fc104ccc040dedbd54"
-  },
-  {
-    "date": "2022-04-21",
-    "version": "0.2.1-rc.33",
-    "container_hash": "4dda84d7008c303cc63278d6060803ae37d024fc80649009912620617c918e06",
-    "git_hash": "ce3d9ecbeb2181e86839b811ada1b77c1ff6e6ab"
-  },
-  {
-    "date": "2022-04-25",
-    "version": "0.2.1-rc.34",
-    "container_hash": "a71d58e9373034a529be4067da6baa7f51717c78a446d277b5423f8d7f20d6b4",
-    "git_hash": "7e735b668d2c74eed0156414b64e3997339f73e5"
-  },
-  {
-    "date": "2022-04-28",
-    "version": "0.2.1-rc.35",
-    "container_hash": "b63abeeef0e8969274049abd9ae51d77321775140a5fdae7fe2a439a3f7c34c5",
-    "git_hash": "b0e850c26613cbd5b5a4131dcf5ccbf201d60876"
-  },
-  {
-    "date": "2022-04-28",
-    "version": "0.2.1-rc.36",
-    "container_hash": "44bb94f7e900293245ef7a47746214605c8ab278bb60150461e2791b18a5ae5c",
-    "git_hash": "2b84431b7175839c894de856227906fbc00e7c69"
-  },
-  {
-    "date": "2022-04-28",
-    "version": "0.2.1-rc.37",
-    "container_hash": "4aef77e1010c3a98aa92e1cb37eda1f7f78a912b98853286ee5360da7d798276",
-    "git_hash": "866f0e9172469e8ae715f908db774d1165f45c5d"
-  },
-  {
-    "date": "2022-04-28",
-    "version": "0.2.1-rc.38",
-    "container_hash": "9f7f4ab9b47e012ab1fdfe99b5646df3d4ad628f4d05748e90e6c90497616497",
-    "git_hash": "105877fd442509d8e016066c3a705f689ba83da3"
-  },
-  {
-    "date": "2022-04-28",
-    "version": "0.2.1-rc.39",
-    "container_hash": "611635bc99e6acfa97a73c2cc1017665bdc2b7cb71cd0fa7aa2d515d70797681",
-    "git_hash": "16e1ccfdbf781ec63f5f8aa821ff59cfcf705a74"
-  },
-  {
-    "date": "2022-04-29",
-    "version": "0.2.1-rc.310",
-    "container_hash": "ceb901e12588943482e808c83509b3d8e66603278ff9e1ed4aae0dc2651da5bb",
-    "git_hash": "3a3e48a30d491294be7d50e3f8fdf48a02fd59d3"
-  },
-  {
-    "date": "2022-04-29",
-    "version": "0.2.1-rc.311",
-    "container_hash": "02434ec97399e7137eb3192154be1d8380d4101a527479776ac2b4290c06c000",
-    "git_hash": "e22b41e633241a743d34da9e9dd04c0794c13f96"
-  },
-  {
-    "date": "2022-05-02",
-    "version": "0.2.1-rc.312",
-    "container_hash": "c277c4be43f3678faffff7305abd7b504adb1ee8f2d83c261eea724f61836f6e",
-    "git_hash": "231fd726834692b94dc53528286dc82caaf92e71"
-  },
-  {
-    "date": "2022-05-05",
-    "version": "0.2.1-rc.313",
-    "container_hash": "20359d69d05fd377b3c3372f0675d5b541a8c023120ea68583c1ad830c808712",
-    "git_hash": "46da8816cad6152d02fe011f07d598a5076ef503"
-  },
-  {
-    "date": "2022-05-05",
-    "version": "0.2.1-rc.314",
-    "container_hash": "454e72dcda9389ffe116d9f52475824c5c9a61484467f3b4c443605038574537",
-    "git_hash": "5a590ecfae9000e9b962372d99a31e8959206dc5"
   },
   {
     "date": "2022-05-08",
@@ -411,28 +11,10 @@
     "git_hash": "745983ef05bfd9a67b1ebb9d90f6c5622fe1d597"
   },
   {
-    "date": "2022-05-09",
-    "version": "1.0.1-rc",
-    "container_hash": "21fd4ca66353e41981f30ac7a322725e2613a4596ff06d5ea28494db405d9abc",
-    "git_hash": "8b1f172dcdcc56ed195edc96a2efb3ccd7b37f54"
-  },
-  {
     "date": "2022-05-10",
     "version": "1.0.0",
     "container_hash": "55f6be610ea42462e7805c861f9e73b1f41c0063fa0c722debda9c78bd8fd1f7",
     "git_hash": "745983ef05bfd9a67b1ebb9d90f6c5622fe1d597"
-  },
-  {
-    "date": "2022-05-12",
-    "version": "1.0.2-rc",
-    "container_hash": "5ca4395e8b36f96a09a709655a13a5288da21a379c0496c618f3bc031ec74892",
-    "git_hash": "6687021cfe78968c69f7a0d45289934f38846f7c"
-  },
-  {
-    "date": "2022-05-16",
-    "version": "1.0.3-rc",
-    "container_hash": "84257bd6415b1f1cc8269e6352f893d00801405384a4ef06b64b391906e239c0",
-    "git_hash": "3e0333be2d3a953e023170f2dc7ddb9ce8e57f85"
   },
   {
     "date": "2022-05-17",
@@ -441,70 +23,16 @@
     "git_hash": "745983ef05bfd9a67b1ebb9d90f6c5622fe1d597"
   },
   {
-    "date": "2022-05-19",
-    "version": "1.0.4-rc",
-    "container_hash": "27143a9b14a134a2dd9b7c8116b336cf5002852f9b7f8c7f2cadfd3806b2a28a",
-    "git_hash": "888587d72b77b43e216bd890a0289785b3580bbb"
-  },
-  {
-    "date": "2022-05-20",
-    "version": "1.0.5-rc",
-    "container_hash": "dff4dadf0578b51fd0990de7bcb9e1da95274700c55d312ad847fd7117ef0b6b",
-    "git_hash": "010b7ce8fbc79d7e753627ca6f04a8e79f78306d"
-  },
-  {
     "date": "2022-05-24",
     "version": "1.0.0",
     "container_hash": "4a8db889239695a36d3f4a90526db959f51cc31a169b71c6894415f4dde4fddb",
     "git_hash": "745983ef05bfd9a67b1ebb9d90f6c5622fe1d597"
   },
   {
-    "date": "2022-05-27",
-    "version": "1.0.7-rc",
-    "container_hash": "ec81e96af41742c9e98a9fa7297422d7fb694057b7761345a32933ec6af16911",
-    "git_hash": "25dafccd48551f7af31b95b2d43c81cf62f62671"
-  },
-  {
     "date": "2022-05-31",
     "version": "1.0.0",
     "container_hash": "aff48b9b7084eb5850ae0453921373de952a3487f5932f0e12bfa5ac7988ef42",
     "git_hash": "745983ef05bfd9a67b1ebb9d90f6c5622fe1d597"
-  },
-  {
-    "date": "2022-06-01",
-    "version": "1.0.8-rc.0",
-    "container_hash": "dd488d536b9240234c03e5a075bd7dac83d6b9cdd071d0e391f91c48b8f52082",
-    "git_hash": "52e72ce0330af54fb990e0fac9cc13e1df394c84"
-  },
-  {
-    "date": "2022-06-01",
-    "version": "1.0.1-rc.10",
-    "container_hash": "51772dac8273b6d1aa3f33790b9547ac0e51c8fd1dd9b89e3603bdc7442f7cc2",
-    "git_hash": "a177070b3746e216e9d0d4f0da09a5a0aa9dab3f"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "1.0.1-rc.11-arm64",
-    "container_hash": "cff7fa3214a8d3a87bc0cc67b7478f41d27c63cf0f7e07bb1700a6155bfefd29",
-    "git_hash": "ee7db2257e3ad2e79f39222588f08fd3a0b96d88"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "1.0.1-rc.11-amd64",
-    "container_hash": "b09ca3064bdba8400b512df63e22f7d3ac6ba5ef05a384566a932ece13345c82",
-    "git_hash": "ee7db2257e3ad2e79f39222588f08fd3a0b96d88"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "1.0.1-rc.12-amd64",
-    "container_hash": "f316cea7809067a43721ff632a4f5c33fa4a419a7f9ddd6748dcb80bb258cc12",
-    "git_hash": "731126179903e6a9d164adf15a57b3d809246d08"
-  },
-  {
-    "date": "2022-06-03",
-    "version": "1.0.1-rc.12-arm64",
-    "container_hash": "e62dc146bee0acd0e371ac231aa51cad970ee22acbe6440b214a56943a0ddc2d",
-    "git_hash": "731126179903e6a9d164adf15a57b3d809246d08"
   },
   {
     "date": "2022-06-03",
@@ -517,18 +45,6 @@
     "version": "1.0.1-arm64",
     "container_hash": "b62576d18d64a7283f0b258d572e721ef57ef4711607a1ca3078a36a54873948",
     "git_hash": "b566f6edab817f282a3faeb17c6ba234dae9b1ab"
-  },
-  {
-    "date": "2022-06-06",
-    "version": "1.0.2-rc.0-amd64",
-    "container_hash": "70b2a880d770669e3c4016ab8a9d992468d4ca17420d4ea2a2cc3d6bf64a4474",
-    "git_hash": "1b60aa69ea94f6b9e403b656c900dbeb6e58e323"
-  },
-  {
-    "date": "2022-06-06",
-    "version": "1.0.2-rc.0-arm64",
-    "container_hash": "eb20869ed16f21b083bad4d5a9b28827810549a3345292ef3cdd3ab0e1d48ae0",
-    "git_hash": "1b60aa69ea94f6b9e403b656c900dbeb6e58e323"
   },
   {
     "date": "2022-06-07",
@@ -567,94 +83,10 @@
     "git_hash": "b566f6edab817f282a3faeb17c6ba234dae9b1ab"
   },
   {
-    "date": "2022-06-14",
-    "version": "1.0.2-rc.4-amd64",
-    "container_hash": "a8fff21c9dc46cf032f77f70733ca220032d0bf02adf2d9a3f6909f02a859c1c",
-    "git_hash": "2f0d4cc6a6530d783e726516ed4eef37e2c611ce"
-  },
-  {
-    "date": "2022-06-14",
-    "version": "1.0.2-rc.4-arm64",
-    "container_hash": "d15ae8d0cb98e6ba9d54173253005b9e80e47f4968ed2e6fd6daf09a7b8f2e06",
-    "git_hash": "2f0d4cc6a6530d783e726516ed4eef37e2c611ce"
-  },
-  {
-    "date": "2022-06-16",
-    "version": "1.0.2-rc.5-arm64",
-    "container_hash": "57ba94b05ef29d210df38aabdcd6632947135064f9f48bc8cf8e7f201fe6b7b0",
-    "git_hash": "748da59d497e1a015f2fd6e3ceaacfc135b71b7f"
-  },
-  {
-    "date": "2022-06-16",
-    "version": "1.0.2-rc.5-amd64",
-    "container_hash": "065743ddfcc044d0c765f690a0ea9c081525267e2cd29ed09263204d6105e9f5",
-    "git_hash": "748da59d497e1a015f2fd6e3ceaacfc135b71b7f"
-  },
-  {
-    "date": "2022-06-16",
-    "version": "1.0.2-rc.6-arm64",
-    "container_hash": "9a437aee8f4448330f74ee4a06da7ab46c7361b826c4f950427847454d9641a5",
-    "git_hash": "8af51c07d966c542854220ffa13ada6a948a97d0"
-  },
-  {
-    "date": "2022-06-16",
-    "version": "1.0.2-rc.6-amd64",
-    "container_hash": "3a7a6971dfd00a575f9497828a9669005fb392d5ff00f2025e6938c1b6c4351a",
-    "git_hash": "8af51c07d966c542854220ffa13ada6a948a97d0"
-  },
-  {
-    "date": "2022-06-17",
-    "version": "1.0.2-rc.8-arm64",
-    "container_hash": "a23fca0f3fd946e366dea151bcc8be5bfba3c1947075577643a51b9eaef5c4b9",
-    "git_hash": "b3944e7883ac0c0f8b5df3a3e575be170e0cfb73"
-  },
-  {
-    "date": "2022-06-17",
-    "version": "1.0.2-rc.8-amd64",
-    "container_hash": "0c87f970b766b3718e71b2c6607e4fa6ab6b09a8370d41f3b38aa923fe91b551",
-    "git_hash": "b3944e7883ac0c0f8b5df3a3e575be170e0cfb73"
-  },
-  {
-    "date": "2022-06-20",
-    "version": "1.0.2-rc.9-arm64",
-    "container_hash": "46d865dc7878dfaa3851009881f68a3edf83a3c0a6bfa6e7943434ca1b685cda",
-    "git_hash": "095606d27733a15bbc168aaea1d1d06d61fa8dad"
-  },
-  {
-    "date": "2022-06-20",
-    "version": "1.0.2-rc.9-amd64",
-    "container_hash": "41f9b4e66f37a544e6a13f82bf55f74438ecf43d156984c09b995caa105ee9f3",
-    "git_hash": "095606d27733a15bbc168aaea1d1d06d61fa8dad"
-  },
-  {
     "date": "2022-06-21",
     "version": "1.0.0",
     "container_hash": "1aa797068d2a5ed0613b6ba516a9e5da5b8e698ecfa15578103c8e91e2faeeb9",
     "git_hash": "745983ef05bfd9a67b1ebb9d90f6c5622fe1d597"
-  },
-  {
-    "date": "2022-06-21",
-    "version": "1.0.2-rc.10-arm64",
-    "container_hash": "9590c48897dd6059ffacc4a4788bb88c5accb52c3b3f0aecd10bc844a2818908",
-    "git_hash": "6741abe1a1bd333154a201a4a4c8e466e0971a4c"
-  },
-  {
-    "date": "2022-06-21",
-    "version": "1.0.2-rc.10-amd64",
-    "container_hash": "14defa96f9103512d314fd5e0a69b39409b02c0a03a21fa18a4fdafad5656642",
-    "git_hash": "6741abe1a1bd333154a201a4a4c8e466e0971a4c"
-  },
-  {
-    "date": "2022-06-23",
-    "version": "1.0.2-rc.11-arm64",
-    "container_hash": "090b7d758a97ce11ce74492989422629c7016a8ca8148854554cdbbde1ca8434",
-    "git_hash": "2b50635a1cb43392e7a5c82ed3a7867604a3f230"
-  },
-  {
-    "date": "2022-06-23",
-    "version": "1.0.2-rc.11-amd64",
-    "container_hash": "b590c7d6aa9b2110bbaafaf4fd9af42c68decd503ea8e8861fed98bebce8a2ad",
-    "git_hash": "2b50635a1cb43392e7a5c82ed3a7867604a3f230"
   },
   {
     "date": "2022-06-28",
@@ -667,48 +99,6 @@
     "version": "1.0.1-amd64",
     "container_hash": "d98987d8f6de547e2db9819494eb6641c042fceab430ab2878e09552501aabec",
     "git_hash": "b566f6edab817f282a3faeb17c6ba234dae9b1ab"
-  },
-  {
-    "date": "2022-06-30",
-    "version": "1.0.2-rc.12-arm64",
-    "container_hash": "d12353a0c54cb18055be3a8c5b69e3392089e55257210ae9ff0a7ef374a1a23c",
-    "git_hash": "54ae301f340872a1a60c9279ce8349a520924803"
-  },
-  {
-    "date": "2022-06-30",
-    "version": "1.0.2-rc.13-arm64",
-    "container_hash": "553bbe6c8cedb77e42e710c538f44372932e2e78b8d85f31297b6439c8c0e04c",
-    "git_hash": "c3ff4807944fe1729b2b77601ebc4f3ce75ce0ab"
-  },
-  {
-    "date": "2022-06-30",
-    "version": "1.0.2-rc.12-amd64",
-    "container_hash": "1856ea2e456961fb7292da80e5458d6acb2ba36d7b0837ff659f0b60de676c55",
-    "git_hash": "54ae301f340872a1a60c9279ce8349a520924803"
-  },
-  {
-    "date": "2022-06-30",
-    "version": "1.0.2-rc.13-amd64",
-    "container_hash": "4677394cebd3505d3f8e35871d23910ddaf5bd7bb3cb7a268c314ba7e12ad7b8",
-    "git_hash": "c3ff4807944fe1729b2b77601ebc4f3ce75ce0ab"
-  },
-  {
-    "date": "2022-06-30",
-    "version": "1.0.2-rc.14-arm64",
-    "container_hash": "4f329bb5a5deff07463539b51764dc52bf6dcc7b781dfbf9a21258af28f7ba3b",
-    "git_hash": "0ecb191bffa4ac91d649f386ad2cf072f4c633b8"
-  },
-  {
-    "date": "2022-06-30",
-    "version": "1.0.2-rc.14-amd64",
-    "container_hash": "cbe97496790dec4ba6d8aa9ef672297dfa92013873e52dfb787ba327aa500550",
-    "git_hash": "0ecb191bffa4ac91d649f386ad2cf072f4c633b8"
-  },
-  {
-    "date": "2022-07-04",
-    "version": "1.0.2-rc.15-amd64",
-    "container_hash": "56b352a11367a8a5bac27ca02442c1ea66ddbe0313f2536054fe6a6d025ca0d6",
-    "git_hash": "2b81d269a4f1febd1fd58e466f83aefd6193d26f"
   },
   {
     "date": "2022-07-05",
@@ -729,30 +119,6 @@
     "git_hash": "b566f6edab817f282a3faeb17c6ba234dae9b1ab"
   },
   {
-    "date": "2022-07-07",
-    "version": "1.0.2-rc.16-arm64",
-    "container_hash": "2a1730571ed7cc73db32536c898cc1c38910122484f20cd0f72ac2b0ed3155b1",
-    "git_hash": "d54b693c43e137af5577fab49475ee198fa02a1c"
-  },
-  {
-    "date": "2022-07-07",
-    "version": "1.0.2-rc.16-amd64",
-    "container_hash": "a5e27593a1a60a80558ed4a35f2791b43e5242e5fcc825bb29c05d9952c543fe",
-    "git_hash": "d54b693c43e137af5577fab49475ee198fa02a1c"
-  },
-  {
-    "date": "2022-07-11",
-    "version": "1.0.2-rc.17-arm64",
-    "container_hash": "3da70c053f63841312ea203b232660ac7422a3494a285a379783232c38879f48",
-    "git_hash": "bbc9f18be8fa8d2cc6f3a433c1ca90f2fb6fb9f0"
-  },
-  {
-    "date": "2022-07-11",
-    "version": "1.0.2-rc.17-amd64",
-    "container_hash": "b37d655a1c54c780af34628931d2b85b77c8b9d5349d62ed88ede41c1519d72d",
-    "git_hash": "bbc9f18be8fa8d2cc6f3a433c1ca90f2fb6fb9f0"
-  },
-  {
     "date": "2022-07-12",
     "version": "1.0.1-arm64",
     "container_hash": "f763d74538a3454080c2c51b512e4a0b80ffd922f5aed8aa59cb768859580776",
@@ -769,66 +135,6 @@
     "version": "1.0.1-amd64",
     "container_hash": "afed2b12641efb4bcb6e2040e5780b24dc6aec13d486fe9a895daa4ba1a18f7c",
     "git_hash": "b566f6edab817f282a3faeb17c6ba234dae9b1ab"
-  },
-  {
-    "date": "2022-07-14",
-    "version": "1.0.2-rc.18-arm64",
-    "container_hash": "ab39d362dc37176496a7ea45c1d447fe74bdeb66a95eb8d87f52a2f40b8721da",
-    "git_hash": "b54cda182d1f7f623a9e305b510a37fe3508b332"
-  },
-  {
-    "date": "2022-07-14",
-    "version": "1.0.2-rc.19-arm64",
-    "container_hash": "f2e95405d72e2fbc86fc450d319cf495cbf1cd36f2a1f7b721e648d938b2d78e",
-    "git_hash": "adbdaf1898f945cf3de7420a0ee6d5fe5175006d"
-  },
-  {
-    "date": "2022-07-14",
-    "version": "1.0.2-rc.18-amd64",
-    "container_hash": "488f2265b966a4c83beb4e5149e7aacc95ae725b8e24640e455b8f94a23655e6",
-    "git_hash": "b54cda182d1f7f623a9e305b510a37fe3508b332"
-  },
-  {
-    "date": "2022-07-14",
-    "version": "1.0.2-rc.20-arm64",
-    "container_hash": "22c905879e4319301b01387dc326fc27226144ae77fe8abb5c07ae2d343ee29d",
-    "git_hash": "8dd88d8ce388b4123ac82e7d30bb2bba634ddf53"
-  },
-  {
-    "date": "2022-07-14",
-    "version": "1.0.2-rc.19-amd64",
-    "container_hash": "1003722c350c771dd35a1b1600000781ece80db448cd18e46083a22fa1221552",
-    "git_hash": "adbdaf1898f945cf3de7420a0ee6d5fe5175006d"
-  },
-  {
-    "date": "2022-07-14",
-    "version": "1.0.2-rc.21-arm64",
-    "container_hash": "515882b7967727a6e87bd66338196cd901e887d25256451ac8dd126b4ad8b917",
-    "git_hash": "8c2a1c3b20be3ef0225c983ae6e1c302b58934bc"
-  },
-  {
-    "date": "2022-07-14",
-    "version": "1.0.2-rc.20-amd64",
-    "container_hash": "eabbd5e17b803f81fb9ca4252e1e8c8fbc0bf999b13a294a9d553d2266b104c7",
-    "git_hash": "8dd88d8ce388b4123ac82e7d30bb2bba634ddf53"
-  },
-  {
-    "date": "2022-07-14",
-    "version": "1.0.2-rc.21-amd64",
-    "container_hash": "6bb04dc8327e4f8b9e7192bbc9a68080f88999c3780ab5ed8f12e0ac33e7e397",
-    "git_hash": "8c2a1c3b20be3ef0225c983ae6e1c302b58934bc"
-  },
-  {
-    "date": "2022-07-14",
-    "version": "1.0.2-rc.22-amd64",
-    "container_hash": "9176da95298f8da673ff1f381158891d39792dc6995069118a5933577f4d75d9",
-    "git_hash": "3fa346773dc3372c739af77338b50fe7d1bd59f9"
-  },
-  {
-    "date": "2022-07-14",
-    "version": "1.0.2-rc.22-arm64",
-    "container_hash": "9895a485d9800b401ea4bb327b51d94f88749d08bf9bb7690ac9b9786784aa3b",
-    "git_hash": "3fa346773dc3372c739af77338b50fe7d1bd59f9"
   },
   {
     "date": "2022-07-19",
@@ -861,18 +167,6 @@
     "git_hash": "67d75b0523ae3f764eb6bbb5ca220c5bbae5ab3e"
   },
   {
-    "date": "2022-07-21",
-    "version": "1.0.2-rc.23-arm64",
-    "container_hash": "5bea73769cc3be6339ecc0c1322bac17f3db98bc6016a56c72468d2cdaffb6f2",
-    "git_hash": "2feee80531e0fa8ef8209cf4422a49523ed6428a"
-  },
-  {
-    "date": "2022-07-21",
-    "version": "1.0.2-rc.23-amd64",
-    "container_hash": "a3bd4eb1d21544adf752e823fc7bb23a933eddaccf5e5776d9014eab19068e22",
-    "git_hash": "2feee80531e0fa8ef8209cf4422a49523ed6428a"
-  },
-  {
     "date": "2022-07-26",
     "version": "1.0.1-arm64",
     "container_hash": "ac73d17a3670db4d33a1aed44ea918a65620fac5fc034b526b3ff136003bdbb3",
@@ -889,30 +183,6 @@
     "version": "1.0.1-amd64",
     "container_hash": "7d4666ce3674761bd06874fc485f8853177ff0328c43323b2909452203a30253",
     "git_hash": "67d75b0523ae3f764eb6bbb5ca220c5bbae5ab3e"
-  },
-  {
-    "date": "2022-07-28",
-    "version": "1.0.2-rc.24-arm64",
-    "container_hash": "f734370dbf02f8f68c63041333c9a1216faae387975918a258d26f75104b880b",
-    "git_hash": "2b6749c9d7f1f9e565c80eb285a37a48ffde364a"
-  },
-  {
-    "date": "2022-07-28",
-    "version": "1.0.2-rc.24-amd64",
-    "container_hash": "f7b4e7c5cfc9a17c04cfd7dc4be1c665605056597784c575454e778ca86ca01e",
-    "git_hash": "2b6749c9d7f1f9e565c80eb285a37a48ffde364a"
-  },
-  {
-    "date": "2022-07-28",
-    "version": "1.0.2-rc.25-arm64",
-    "container_hash": "f57e2848e1c832beefa95091faeb2daceec4f1fbd585aabbeaafdae14ec92642",
-    "git_hash": "563d682e465b5eb43dcecc436c5fd9fa4ccf45f4"
-  },
-  {
-    "date": "2022-07-28",
-    "version": "1.0.2-rc.25-amd64",
-    "container_hash": "342d7a66bb2981fdffaa17b05b3663d28092be5df71f2d10de5fbb6b7696e408",
-    "git_hash": "563d682e465b5eb43dcecc436c5fd9fa4ccf45f4"
   },
   {
     "date": "2022-08-02",
@@ -933,18 +203,6 @@
     "git_hash": "745983ef05bfd9a67b1ebb9d90f6c5622fe1d597"
   },
   {
-    "date": "2022-08-04",
-    "version": "1.0.2-rc.26-arm64",
-    "container_hash": "6047ee373d609054869bcc2fe46cfb6ccb37e323962f4c2ab481a285ab7fbb57",
-    "git_hash": "8064679e0dfff7c0598714cf9b786e8230b36ce1"
-  },
-  {
-    "date": "2022-08-04",
-    "version": "1.0.2-rc.26-amd64",
-    "container_hash": "3ef1869bf5162c969f4ead04b21126d2dff28b7380cc3fbe17f8e241271176cd",
-    "git_hash": "8064679e0dfff7c0598714cf9b786e8230b36ce1"
-  },
-  {
     "date": "2022-08-09",
     "version": "1.0.1-arm64",
     "container_hash": "ac73d17a3670db4d33a1aed44ea918a65620fac5fc034b526b3ff136003bdbb3",
@@ -961,54 +219,6 @@
     "version": "1.0.1-amd64",
     "container_hash": "28c1c77807a3a6a4a939139d7ee6764967f73faee1e8c68d0b5e0ba9c6431bea",
     "git_hash": "67d75b0523ae3f764eb6bbb5ca220c5bbae5ab3e"
-  },
-  {
-    "date": "2022-08-10",
-    "version": "1.0.2-rc.27-amd64",
-    "container_hash": "b80e1c5b733fcc85c84d049307c70306a7b3988aa73da931cf17a2a9a1feaeb2",
-    "git_hash": "4572a0b2968a6ff993a99c235e59872d47cc67d8"
-  },
-  {
-    "date": "2022-08-10",
-    "version": "1.0.2-rc.27-arm64",
-    "container_hash": "eb6fe98aa11ca92feeb4d3a14b129c2548ad238c418e279c756232ed644a79d5",
-    "git_hash": "4572a0b2968a6ff993a99c235e59872d47cc67d8"
-  },
-  {
-    "date": "2022-08-11",
-    "version": "1.0.2-rc.28-amd64",
-    "container_hash": "00df183d320149de87d8038b457bba8ea6a16376657458bc250d78ba8d52c831",
-    "git_hash": "3f024a44f75ff60975f7879c972bdf06dcf5c6f9"
-  },
-  {
-    "date": "2022-08-11",
-    "version": "1.0.2-rc.28-arm64",
-    "container_hash": "5432597a9862ea4b82ac6ae13aff87c683cf6b9366ad69f510bd6df8939507e8",
-    "git_hash": "3f024a44f75ff60975f7879c972bdf06dcf5c6f9"
-  },
-  {
-    "date": "2022-08-11",
-    "version": "1.0.2-rc.29-arm64",
-    "container_hash": "114dd61ecb04cd2a01efd9f6399b74d92d2986aea55aa77ae272f0e134449ea5",
-    "git_hash": "a1b241e15e7d3f3eff752e5e5f88031d0d3e4a38"
-  },
-  {
-    "date": "2022-08-11",
-    "version": "1.0.2-rc.29-amd64",
-    "container_hash": "0acf6000318db782dd794bdce123cab8a21abab6d94a4bf71f30c6e0ad3ea54d",
-    "git_hash": "a1b241e15e7d3f3eff752e5e5f88031d0d3e4a38"
-  },
-  {
-    "date": "2022-08-15",
-    "version": "1.0.2-rc.30-amd64",
-    "container_hash": "4dc5903b9f27dd64def77539c785165f5763a743a1d1dff3892e3c08f9e1f3dc",
-    "git_hash": "708306920832f5b1363a4ba5a0a3f9cf26f43ada"
-  },
-  {
-    "date": "2022-08-15",
-    "version": "1.0.2-rc.30-arm64",
-    "container_hash": "d736baea1a2a60898022d798e0d249b147ef76a09e5923dd38a318ab6e9e8ebb",
-    "git_hash": "708306920832f5b1363a4ba5a0a3f9cf26f43ada"
   },
   {
     "date": "2022-08-16",
@@ -1047,24 +257,6 @@
     "git_hash": "67d75b0523ae3f764eb6bbb5ca220c5bbae5ab3e"
   },
   {
-    "date": "2022-08-25",
-    "version": "1.0.2-rc.31-arm64",
-    "container_hash": "6215113ac4c9ea18a23ebb546c052e1e488b0cbcdff5bb36e53fe6708a0e8133",
-    "git_hash": "4eb25c002045e58a44bc7b17b1084da2b05ee25c"
-  },
-  {
-    "date": "2022-08-25",
-    "version": "1.0.2-rc.31-amd64",
-    "container_hash": "69144a8ef4d739d5f0a491ae50d571856a44984756697727f91f80fe36aabce9",
-    "git_hash": "4eb25c002045e58a44bc7b17b1084da2b05ee25c"
-  },
-  {
-    "date": "2022-08-29",
-    "version": "1.0.2-rc.32-amd64",
-    "container_hash": "cb52e7ea28960911f9f550400c99b5abd37721211b3001a09fb8c4e32582daf6",
-    "git_hash": "ead0577cfaf7f83226e33b80abe023ec17489eea"
-  },
-  {
     "date": "2022-08-30",
     "version": "1.0.1-arm64",
     "container_hash": "4a5d0baec242ca8127859598dc23c47e469bbb5842f3d5cb9cedf19fb728795a",
@@ -1081,18 +273,6 @@
     "version": "1.0.1-amd64",
     "container_hash": "bfacba590d4023e9324c6d0418dc7f12a5f7a309fdee47006211a8a8472fd233",
     "git_hash": "67d75b0523ae3f764eb6bbb5ca220c5bbae5ab3e"
-  },
-  {
-    "date": "2022-09-01",
-    "version": "1.0.2-rc.33-arm64",
-    "container_hash": "2f8cf2ab860058fe4b526a9cae217504c851b1b1dc2fe5bc5de943ad594d5841",
-    "git_hash": "3f5dff33b2138fcd599ce947338e2006c494c955"
-  },
-  {
-    "date": "2022-09-01",
-    "version": "1.0.2-rc.33-amd64",
-    "container_hash": "c439925f8af97fcc8038808d469db2bcabac9967248e841afb1e37d708866218",
-    "git_hash": "3f5dff33b2138fcd599ce947338e2006c494c955"
   },
   {
     "date": "2022-09-06",
@@ -1113,42 +293,6 @@
     "git_hash": "745983ef05bfd9a67b1ebb9d90f6c5622fe1d597"
   },
   {
-    "date": "2022-09-07",
-    "version": "1.0.2-rc.34-arm64",
-    "container_hash": "d1cf3c1030580b4a37dd7cba83d3b08e8d0c71ed893bf077c02bdbb1fb4f6f1b",
-    "git_hash": "3e4fbd2f5c4f3ea75e12656b65c77a82155fc464"
-  },
-  {
-    "date": "2022-09-07",
-    "version": "1.0.2-rc.34-amd64",
-    "container_hash": "a19cab7f0bd0eb43d209df5167bce195ef13105c914b1967283046934bdce528",
-    "git_hash": "3e4fbd2f5c4f3ea75e12656b65c77a82155fc464"
-  },
-  {
-    "date": "2022-09-08",
-    "version": "1.0.2-rc.35-amd64",
-    "container_hash": "9a80aa0e1bf01d0b8c8c7aa9c15a5bdb67dde1a5af8963fb392293d008bf5065",
-    "git_hash": "0961eba1d9a75c748ce9ab9d2a34a6cb7ac40264"
-  },
-  {
-    "date": "2022-09-08",
-    "version": "1.0.2-rc.35-arm64",
-    "container_hash": "1620010e8dd7dc4800ac1a6059439fce8b8e05da1b67dcc844dfc658fc190535",
-    "git_hash": "0961eba1d9a75c748ce9ab9d2a34a6cb7ac40264"
-  },
-  {
-    "date": "2022-09-08",
-    "version": "1.0.2-rc.36-arm64",
-    "container_hash": "b632acc9ef4855afa200e1220ada438a840b80d9c925642701f8a8344a99f013",
-    "git_hash": "682a803861c731f8d29e8bb36d129848f53d5d83"
-  },
-  {
-    "date": "2022-09-09",
-    "version": "1.0.2-rc.36-amd64",
-    "container_hash": "408b38bd60bc66b636053464beaef1c3016173a5ad80824e99cb1160e73b8d28",
-    "git_hash": "682a803861c731f8d29e8bb36d129848f53d5d83"
-  },
-  {
     "date": "2022-09-13",
     "version": "1.0.1-arm64",
     "container_hash": "4a5d0baec242ca8127859598dc23c47e469bbb5842f3d5cb9cedf19fb728795a",
@@ -1165,54 +309,6 @@
     "version": "1.0.0",
     "container_hash": "19090851aeba533883053ed6a0615de9fe49710d71dec5987c776c91deb7070c",
     "git_hash": "745983ef05bfd9a67b1ebb9d90f6c5622fe1d597"
-  },
-  {
-    "date": "2022-09-16",
-    "version": "1.0.2-rc.37-amd64",
-    "container_hash": "0a76555b4691b701485f8255bf25cdbee3ee28e7796c8d26878845c42ce61df2",
-    "git_hash": "da69b75c9fe57a71c775be7c8c184ead8124df19"
-  },
-  {
-    "date": "2022-09-16",
-    "version": "1.0.2-rc.38-amd64",
-    "container_hash": "87f5a9bd2c6aba0bdf1d1a825bae5245d1e97f747ed3a297c6e2d795131fa453",
-    "git_hash": "f101a1e3464df703f2883f3b3e533ce6f4a53920"
-  },
-  {
-    "date": "2022-09-16",
-    "version": "1.0.2-rc.38-arm64",
-    "container_hash": "414e4dffaf4a856c328770f98c2c045cf7ef9046bea6fbd5b9f745b9ea1c384b",
-    "git_hash": "f101a1e3464df703f2883f3b3e533ce6f4a53920"
-  },
-  {
-    "date": "2022-09-16",
-    "version": "1.0.2-rc.37-arm64",
-    "container_hash": "add52537f4acdc24ef78a346c24efc2d0ee7d169e920c8152bfa5531fcd7a9f5",
-    "git_hash": "da69b75c9fe57a71c775be7c8c184ead8124df19"
-  },
-  {
-    "date": "2022-09-16",
-    "version": "1.0.2-rc.39-amd64",
-    "container_hash": "4cfe4bc976f5c506c784a95cab38a177d0b3dd989019aa39ed6914a2c031d56f",
-    "git_hash": "d304ced17c2d6d3a471eb932739e47b8f3afc494"
-  },
-  {
-    "date": "2022-09-16",
-    "version": "1.0.2-rc.40-amd64",
-    "container_hash": "65467655108e8ad639bc94b58f4cd4376ad7a821c9505e1c2f779a9e2ea6d009",
-    "git_hash": "1f9d1c6e47e59cd29d3bb246d30c93dc7a153e8b"
-  },
-  {
-    "date": "2022-09-16",
-    "version": "1.0.2-rc.39-arm64",
-    "container_hash": "f98246ac1f705514654fd4a8c17b4de0c9224d0fd3b218226e3b4c79a3bedee5",
-    "git_hash": "d304ced17c2d6d3a471eb932739e47b8f3afc494"
-  },
-  {
-    "date": "2022-09-16",
-    "version": "1.0.2-rc.40-arm64",
-    "container_hash": "e9f9cd43fef175ea52573da2f68039bc7357a4be79d8d838a919949cf8fe7310",
-    "git_hash": "1f9d1c6e47e59cd29d3bb246d30c93dc7a153e8b"
   },
   {
     "date": "2022-09-20",
@@ -1233,30 +329,6 @@
     "git_hash": "67d75b0523ae3f764eb6bbb5ca220c5bbae5ab3e"
   },
   {
-    "date": "2022-09-22",
-    "version": "1.0.2-rc.41-amd64",
-    "container_hash": "6e91f5b8859f65db05a55073c99c7026abdb4ba26b89513d7097110753c8af12",
-    "git_hash": "28275a092ae7a7276037f64fbbff119f3c086e6b"
-  },
-  {
-    "date": "2022-09-22",
-    "version": "1.0.2-rc.41-arm64",
-    "container_hash": "8beda6d83a1cea177122fa6dad4c012b4d02ae78ec3404fc1d31898d1f13c831",
-    "git_hash": "28275a092ae7a7276037f64fbbff119f3c086e6b"
-  },
-  {
-    "date": "2022-09-22",
-    "version": "1.0.2-rc.42-amd64",
-    "container_hash": "6401325d8a6d41fccd8b39fa5814cb8ff5cf2413a6e4d025fb0876d4cca37b28",
-    "git_hash": "0f329c4039ddfccd12dc37c4817bb6211fd576b4"
-  },
-  {
-    "date": "2022-09-22",
-    "version": "1.0.2-rc.42-arm64",
-    "container_hash": "8a3aab3bad576398a154345d600375c9f311e9c978a9ff17a54227694f23c7c8",
-    "git_hash": "0f329c4039ddfccd12dc37c4817bb6211fd576b4"
-  },
-  {
     "date": "2022-09-27",
     "version": "1.0.1-arm64",
     "container_hash": "4a5d0baec242ca8127859598dc23c47e469bbb5842f3d5cb9cedf19fb728795a",
@@ -1275,42 +347,6 @@
     "git_hash": "745983ef05bfd9a67b1ebb9d90f6c5622fe1d597"
   },
   {
-    "date": "2022-09-29",
-    "version": "1.0.2-rc.43-arm64",
-    "container_hash": "55719f1d2fab12fce2bb9c54f377c84f6ddcd4e47b5455b08dd4859e5179a438",
-    "git_hash": "96eecc11827169ff815cf6fb82a4c803058ea647"
-  },
-  {
-    "date": "2022-09-29",
-    "version": "1.0.2-rc.43-amd64",
-    "container_hash": "d9053ff63b03b08832126a04a7d53a06e7adbe5effbafd689fc0c162f0425768",
-    "git_hash": "96eecc11827169ff815cf6fb82a4c803058ea647"
-  },
-  {
-    "date": "2022-09-29",
-    "version": "1.0.2-rc.44-arm64",
-    "container_hash": "b10b8614561ef5c19daf62fdecf95a86f62d8875caa3c88a60c435388b8cfea3",
-    "git_hash": "da7650148374ccd7101dc326547e9fc50f96e713"
-  },
-  {
-    "date": "2022-09-29",
-    "version": "1.0.2-rc.44-amd64",
-    "container_hash": "25f247787987892ec542af3f56e04ff6984e4968faa5c06bccb0063c35e7ded6",
-    "git_hash": "da7650148374ccd7101dc326547e9fc50f96e713"
-  },
-  {
-    "date": "2022-09-30",
-    "version": "1.0.2-rc.45-arm64",
-    "container_hash": "bafc803d854716b973f335244b024083f91c427ecf4ef55b9f68dbd179abe3f6",
-    "git_hash": "a3484752557ac49f6f83b5be64c08bc17943951f"
-  },
-  {
-    "date": "2022-09-30",
-    "version": "1.0.2-rc.45-amd64",
-    "container_hash": "0899411639902b2cb19b78a2898c1a84f4dd8ae75df7a01810857558b6f8c836",
-    "git_hash": "a3484752557ac49f6f83b5be64c08bc17943951f"
-  },
-  {
     "date": "2022-10-04",
     "version": "1.0.1-arm64",
     "container_hash": "4a5d0baec242ca8127859598dc23c47e469bbb5842f3d5cb9cedf19fb728795a",
@@ -1327,18 +363,6 @@
     "version": "1.0.1-amd64",
     "container_hash": "8e3c1465d44a4730fb4fdad7492e13bd44b92a5588829b5763d4e5cd106e288d",
     "git_hash": "67d75b0523ae3f764eb6bbb5ca220c5bbae5ab3e"
-  },
-  {
-    "date": "2022-10-06",
-    "version": "1.0.2-rc.46-arm64",
-    "container_hash": "5e504584d39bf07dfe236e3be5daed7d5141f832b191f4d0f17b8d84d2d49a25",
-    "git_hash": "7c7e225a42789ed1e59e896ca500becfe2978e6a"
-  },
-  {
-    "date": "2022-10-06",
-    "version": "1.0.2-rc.46-amd64",
-    "container_hash": "a264436bc1f2fbf23c0e091acd28a5fd9e42bd6285cfc55bd7fa4bc66941ab66",
-    "git_hash": "7c7e225a42789ed1e59e896ca500becfe2978e6a"
   },
   {
     "date": "2022-10-11",
@@ -1395,46 +419,10 @@
     "git_hash": "67d75b0523ae3f764eb6bbb5ca220c5bbae5ab3e"
   },
   {
-    "date": "2022-10-25",
-    "version": "1.0.2-rc.48-amd64",
-    "container_hash": "e70c6e07685028131d12e0c59dd290e654e87da4059b38ed25943a3e46ecdb11",
-    "git_hash": "8d2c0b4d4c9b083c44ffbef57886fb7a62cabdfa"
-  },
-  {
-    "date": "2022-10-25",
-    "version": "1.0.2-rc.48-arm64",
-    "container_hash": "2414f2d7c8633b350e96059d12f1bca063a93d82b21f7d0cc85c10a00c7f5483",
-    "git_hash": "8d2c0b4d4c9b083c44ffbef57886fb7a62cabdfa"
-  },
-  {
-    "date": "2022-10-27",
-    "version": "1.0.2-rc.49-arm64",
-    "container_hash": "cf5f8aab18ecc4cd98550df492dbc675f5bbc61c53c3a6a3fc2b7d99dc57b59c",
-    "git_hash": "7d4f91246874acc5bb6d94d5a82919c76a2821d8"
-  },
-  {
-    "date": "2022-10-27",
-    "version": "1.0.2-rc.49-amd64",
-    "container_hash": "7a55fdf3ce428539f4e8a0a81a7a04a328bb818607b11960e9ac7f3d28685ce0",
-    "git_hash": "7d4f91246874acc5bb6d94d5a82919c76a2821d8"
-  },
-  {
     "date": "2022-11-01",
     "version": "1.0.0",
     "container_hash": "e5ee5893c42755083d33abfa878103e46520c22e4909357b56ff992a1d883ae9",
     "git_hash": "745983ef05bfd9a67b1ebb9d90f6c5622fe1d597"
-  },
-  {
-    "date": "2022-11-03",
-    "version": "1.0.2-rc.50-amd64",
-    "container_hash": "4653b40e712982a861f219d35f27600f2872e92b5ca8a4606933186072fd393d",
-    "git_hash": "1718074b8f74b9be1fadb1f5722a6e922da9ca5b"
-  },
-  {
-    "date": "2022-11-03",
-    "version": "1.0.2-rc.50-arm64",
-    "container_hash": "f14fed1a0e14c8f13aa860bef0b9a42c8d4d452579662091ae43994774cd31a0",
-    "git_hash": "1718074b8f74b9be1fadb1f5722a6e922da9ca5b"
   },
   {
     "date": "2022-11-08",
@@ -1455,18 +443,6 @@
     "git_hash": "745983ef05bfd9a67b1ebb9d90f6c5622fe1d597"
   },
   {
-    "date": "2022-11-10",
-    "version": "1.0.2-rc.51-arm64",
-    "container_hash": "ff887be5f9322a6878b531c4ddb80753cd564c015e6780e635f748de171887b2",
-    "git_hash": "c3cab66344b8ae0139edc24afa5763f5c8c2950a"
-  },
-  {
-    "date": "2022-11-10",
-    "version": "1.0.2-rc.51-amd64",
-    "container_hash": "4a389e97930fd3aafe51cb4e1577b46aa46536d460351c10e9791338726c00bc",
-    "git_hash": "c3cab66344b8ae0139edc24afa5763f5c8c2950a"
-  },
-  {
     "date": "2022-11-15",
     "version": "1.0.1-arm64",
     "container_hash": "20e950d126c7a2ff79673cc52a0d793b02a304b7a1920bc79fb52396e6db9fe6",
@@ -1483,42 +459,6 @@
     "version": "1.0.1-amd64",
     "container_hash": "1f19e0b3af0545d6df854fdd4b4a12e8fae7f41debcc4d9e6bd8a8285c347bd7",
     "git_hash": "67d75b0523ae3f764eb6bbb5ca220c5bbae5ab3e"
-  },
-  {
-    "date": "2022-11-17",
-    "version": "1.0.2-rc.52-arm64",
-    "container_hash": "d89a5bd7eedb52f852d6306db272702cd11d25c174ef9abf8cb546011a6b9917",
-    "git_hash": "aecd88be2cb550a4c7bcad0f3eca589325bff6f4"
-  },
-  {
-    "date": "2022-11-17",
-    "version": "1.0.2-rc.52-amd64",
-    "container_hash": "8209bb739d96d2ff443290269a2d1bc4790defa6c39558ba33d7e29d7f63a065",
-    "git_hash": "aecd88be2cb550a4c7bcad0f3eca589325bff6f4"
-  },
-  {
-    "date": "2022-11-18",
-    "version": "1.0.2-rc.53-arm64",
-    "container_hash": "ffc11c2978f024a00db708fff4a9ce4e72c50c9d7a142221fda409e7e4ebf486",
-    "git_hash": "e86c7a5152d86c28adc530623774a2e1a91fd2c1"
-  },
-  {
-    "date": "2022-11-18",
-    "version": "1.0.2-rc.53-amd64",
-    "container_hash": "ceda16e9c0fd6d8212d964d24fa30aac3e1d4e92de72a9d40ea87d04f9954d2c",
-    "git_hash": "e86c7a5152d86c28adc530623774a2e1a91fd2c1"
-  },
-  {
-    "date": "2022-11-21",
-    "version": "1.0.2-rc.54-arm64",
-    "container_hash": "1668c3762052dc9502cc6cc9c3c6a6eef3aec7eac9afa78c531c232eb44c3b9d",
-    "git_hash": "5459157eea92734a17f27e1f8a06c692ada4cc10"
-  },
-  {
-    "date": "2022-11-21",
-    "version": "1.0.2-rc.54-amd64",
-    "container_hash": "1d029a2f13fbb35199e15571b49b5e9a472050672260471716f192debd96be8b",
-    "git_hash": "5459157eea92734a17f27e1f8a06c692ada4cc10"
   },
   {
     "date": "2022-11-22",
@@ -1539,18 +479,6 @@
     "git_hash": "745983ef05bfd9a67b1ebb9d90f6c5622fe1d597"
   },
   {
-    "date": "2022-11-28",
-    "version": "1.0.2-rc.55-arm64",
-    "container_hash": "f9ef667a1ec700a06c3f1fb7f58103ef9a5b5da03628ccf7f8ed48151a4ac2f0",
-    "git_hash": "31595e0978397f8ef388a22da71f84b5314484ba"
-  },
-  {
-    "date": "2022-11-28",
-    "version": "1.0.2-rc.55-amd64",
-    "container_hash": "4c5b63ecaa23d659f7a7674eab79e5aaa5c65fdbeedb5e3bfcf1f030028abdde",
-    "git_hash": "31595e0978397f8ef388a22da71f84b5314484ba"
-  },
-  {
     "date": "2022-11-29",
     "version": "1.0.1-arm64",
     "container_hash": "20e950d126c7a2ff79673cc52a0d793b02a304b7a1920bc79fb52396e6db9fe6",
@@ -1569,106 +497,10 @@
     "git_hash": "745983ef05bfd9a67b1ebb9d90f6c5622fe1d597"
   },
   {
-    "date": "2022-12-01",
-    "version": "1.0.2-rc.56-amd64",
-    "container_hash": "3ceaa718a98411fd2d011e90a866a612ecca96c3269f3c7fb29ee0b4715ff3e1",
-    "git_hash": "7bf994b8734005f9c6ac7d91a4cafb322e6be050"
-  },
-  {
-    "date": "2022-12-01",
-    "version": "1.0.2-rc.56-arm64",
-    "container_hash": "c0d3d9472cbceed6cb73e3eddcdc228c9ddd120394d63c32e009381191713bd4",
-    "git_hash": "7bf994b8734005f9c6ac7d91a4cafb322e6be050"
-  },
-  {
-    "date": "2022-12-01",
-    "version": "1.0.2-rc.57-amd64",
-    "container_hash": "fd0d7d20e492acd56bfb693dd8463ec15d1009f4e8bf53bccd2c32665b1ddf25",
-    "git_hash": "8b0a9812717fb18fa38386454caa597bf1d10c73"
-  },
-  {
-    "date": "2022-12-01",
-    "version": "1.0.2-rc.57-arm64",
-    "container_hash": "4650a4234d9a2c0c22ed65898159a528930cd0b75e65667dbeb0032af183dd0e",
-    "git_hash": "8b0a9812717fb18fa38386454caa597bf1d10c73"
-  },
-  {
-    "date": "2022-12-01",
-    "version": "1.0.2-rc.58-arm64",
-    "container_hash": "f220193272cb7b72cda558a802df58acb3843e42c044a8d8c7d7cc430b944ab6",
-    "git_hash": "3e64dbf2d623f77ff7fed50a98013ce5a2feaeab"
-  },
-  {
-    "date": "2022-12-01",
-    "version": "1.0.2-rc.58-amd64",
-    "container_hash": "9c2ee9a949fecc5d3bd852028b1786e96a12b2a78c1a89c0a12712531a9210a7",
-    "git_hash": "3e64dbf2d623f77ff7fed50a98013ce5a2feaeab"
-  },
-  {
     "date": "2022-12-06",
     "version": "1.0.0",
     "container_hash": "4a3cabed4bd212385969a544e0b1e6a139e6f94dac6e234937531019a1d6aba0",
     "git_hash": "745983ef05bfd9a67b1ebb9d90f6c5622fe1d597"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "1.0.2-rc.59-amd64",
-    "container_hash": "e8d60733ebd85b3352e511d22512a246c47b879a5204d8b31a4c9d307210fd89",
-    "git_hash": "8f3f220d563277574f1447470ec89fad2f5ada87"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "1.0.2-rc.60-amd64",
-    "container_hash": "0c440d8238a624c28e275539d32b113c16b4d3a1e2b33119778580929d398f01",
-    "git_hash": "d9d38e3aa38c274c5a96d5d4b7fdbc323493d1a9"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "1.0.2-rc.61-amd64",
-    "container_hash": "58be1ff95ea9647f7586d5d6b971f20af9edcd03ccbca3d756346ca80b91b97d",
-    "git_hash": "8b5b142fbbd82ca21b77b14bc6a419ac97891ba2"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "1.0.2-rc.59-arm64",
-    "container_hash": "426ebd86a6402faf72e78ccbdb21b589e254d8e5b3ef8cebbcc0e93ddc265cea",
-    "git_hash": "8f3f220d563277574f1447470ec89fad2f5ada87"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "1.0.2-rc.62-amd64",
-    "container_hash": "fa6a602458361f859aaacedb5c2edcb0f6ef687fbe0a609ca8a19f5c18f32ccb",
-    "git_hash": "4379bd5cd149b4d02d47fca90a9594522952f336"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "1.0.2-rc.60-arm64",
-    "container_hash": "9e0201ab3f52bdbf8f2ad78c4ee4cd19a07918c0a59ae136a306833d92d5b816",
-    "git_hash": "d9d38e3aa38c274c5a96d5d4b7fdbc323493d1a9"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "1.0.2-rc.61-arm64",
-    "container_hash": "281303f65a6d42915ce1f1de45c2c1e24fa3213c2a795ad5d9942494d56b4d30",
-    "git_hash": "8b5b142fbbd82ca21b77b14bc6a419ac97891ba2"
-  },
-  {
-    "date": "2022-12-09",
-    "version": "1.0.2-rc.62-arm64",
-    "container_hash": "0cd3302ea7208d5cbb43c58f384a5a303bbc187953c7642f1e3da8ae4103aab1",
-    "git_hash": "4379bd5cd149b4d02d47fca90a9594522952f336"
-  },
-  {
-    "date": "2022-12-12",
-    "version": "1.0.2-rc.63-arm64",
-    "container_hash": "b82ee0060cefdb21d5e23bcfbba07047cb27e199b59417bfdb66fa24d6d1f3c7",
-    "git_hash": "3a399bd08f951ba18364087c2ddb9beb008ec0f3"
-  },
-  {
-    "date": "2022-12-12",
-    "version": "1.0.2-rc.63-amd64",
-    "container_hash": "6907635ea9f9eebfe6c1645567466170e3a48f903954c356a1cc820f8fd2a1c9",
-    "git_hash": "3a399bd08f951ba18364087c2ddb9beb008ec0f3"
   },
   {
     "date": "2022-12-13",
@@ -1689,30 +521,6 @@
     "git_hash": "67d75b0523ae3f764eb6bbb5ca220c5bbae5ab3e"
   },
   {
-    "date": "2022-12-15",
-    "version": "1.0.2-rc.64-amd64",
-    "container_hash": "bf2106a58fdbec2245951bdf10f770ed57bc426f3bb6aa018aff8e91b0ea9d4a",
-    "git_hash": "c8568ccf4c548caba87b73b96849322fa92b8a5f"
-  },
-  {
-    "date": "2022-12-16",
-    "version": "1.0.2-rc.64-arm64",
-    "container_hash": "d3fea38dff45eea14b7fbbc2ae1ac11104741461e5191fe0694509076f86005a",
-    "git_hash": "c8568ccf4c548caba87b73b96849322fa92b8a5f"
-  },
-  {
-    "date": "2023-01-05",
-    "version": "1.0.2-rc.68-arm64",
-    "container_hash": "44564789898b335a07b0b15487ebd6b853ba964296869dccb0087afacdf563f7",
-    "git_hash": "1cfe428d219755c18d56fd4fb353b562502c00f9"
-  },
-  {
-    "date": "2023-01-05",
-    "version": "1.0.2-rc.68-amd64",
-    "container_hash": "59d0f891e6f9b9d08da3bfe845ea0bb7d2303046965ea579d38316fe60a4f45f",
-    "git_hash": "1cfe428d219755c18d56fd4fb353b562502c00f9"
-  },
-  {
     "date": "2023-01-10",
     "version": "1.0.1-arm64",
     "container_hash": "f3244a50051a4026bdcb9ed97f22dbeed5ac98e2c4b23bab688966bfa24c466a",
@@ -1729,36 +537,6 @@
     "version": "1.0.1-amd64",
     "container_hash": "58824eaa942db8182916b70741cedd8ea59d04ac4a2d65f169ea9320b8dea6b8",
     "git_hash": "67d75b0523ae3f764eb6bbb5ca220c5bbae5ab3e"
-  },
-  {
-    "date": "2023-01-10",
-    "version": "1.0.2-rc.70-arm64",
-    "container_hash": "4b75e9c0bc7d5d6a3f53eb6fa47946d1ff821f7ad61a8a115a83448607d215a2",
-    "git_hash": "94225becbed9540f39e2a452d942b323bd23ae35"
-  },
-  {
-    "date": "2023-01-10",
-    "version": "1.0.2-rc.70-amd64",
-    "container_hash": "74d528cc1f02eca7856e73d164c6d9b6f88f5c747f38b29df45623fc1b67dc70",
-    "git_hash": "94225becbed9540f39e2a452d942b323bd23ae35"
-  },
-  {
-    "date": "2023-01-12",
-    "version": "1.0.2-rc.71-arm64",
-    "container_hash": "de959a9ef8620833f67c2efe07c56738dc25698f86868c9d2fd08b6db2b1a3dd",
-    "git_hash": "ac8e1b317dad46f3ec3250374696a88523f09db2"
-  },
-  {
-    "date": "2023-01-12",
-    "version": "1.0.2-rc.71-amd64",
-    "container_hash": "294b8f0f10ea6f2ece07f84644a1b3ac62f9759319900b0749d52db052c01b49",
-    "git_hash": "ac8e1b317dad46f3ec3250374696a88523f09db2"
-  },
-  {
-    "date": "2023-01-16",
-    "version": "1.0.2-rc.72-amd64",
-    "container_hash": "e1e4a00b9d070a84535f48f57ac8ba57e660e64a5c9a14c67fe6452eb327fa0d",
-    "git_hash": "f75a3e0805e88072bf45cf3584ecdc2496e2b5b9"
   },
   {
     "date": "2023-01-17",
@@ -1779,24 +557,6 @@
     "git_hash": "745983ef05bfd9a67b1ebb9d90f6c5622fe1d597"
   },
   {
-    "date": "2023-01-19",
-    "version": "1.0.2-rc.73-amd64",
-    "container_hash": "d9f488ffb64a2f096e486bcecb7fc3d18fb30e5cdf4651054a168ef76169a4e0",
-    "git_hash": "35678522881a56facf400509931fe763185ae88f"
-  },
-  {
-    "date": "2023-01-19",
-    "version": "1.0.2-rc.73-arm64",
-    "container_hash": "738f5b5c5adc07114d75dcf916285cd594549a58f8d0409f14a396cbdd1aa4d4",
-    "git_hash": "35678522881a56facf400509931fe763185ae88f"
-  },
-  {
-    "date": "2023-01-20",
-    "version": "1.0.2-rc.74-amd64",
-    "container_hash": "41944e58a70e402e341877fa9f80462df76dd465c311adb9fc27cd02c2e6ecf4",
-    "git_hash": "b08cfb369c5608905582c9f56335ebcc8d1d07ad"
-  },
-  {
     "date": "2023-01-24",
     "version": "1.0.1-amd64",
     "container_hash": "68f7c167c51895b7f40cf5af5a91f6294539e91be1ddc319b9c61bb4a724417e",
@@ -1807,30 +567,6 @@
     "version": "1.0.0",
     "container_hash": "4fe8459e845de9df5329c5afa5f0e20dff0358730dd180967d1aa792f6060dcf",
     "git_hash": "745983ef05bfd9a67b1ebb9d90f6c5622fe1d597"
-  },
-  {
-    "date": "2023-01-26",
-    "version": "1.0.2-rc.75-arm64",
-    "container_hash": "e5afa5f9502c3c6473187b74c308b3d26c20cc071c16127d73e0dba1121ff7a7",
-    "git_hash": "9ec07eda78799e326c0adf11fec2fc20bd0aa78d"
-  },
-  {
-    "date": "2023-01-27",
-    "version": "1.0.2-rc.75-amd64",
-    "container_hash": "6d2ff26a8a1b5d86aecac5ed3372a414381e1c3994f8c436ef15d1c9012929c9",
-    "git_hash": "9ec07eda78799e326c0adf11fec2fc20bd0aa78d"
-  },
-  {
-    "date": "2023-01-27",
-    "version": "1.0.2-rc.76-arm64",
-    "container_hash": "d6b7f65578fb021bc0b4e4a4f893839574741fd7ba4d819d8efd4deaeb7f02ac",
-    "git_hash": "8d88337cf3b37d530c523774d72b3ee05fd2209a"
-  },
-  {
-    "date": "2023-01-27",
-    "version": "1.0.2-rc.76-amd64",
-    "container_hash": "4afdad436da6f5a587cf0fd488284d8b2fb9d5a372af715bea36008e9d1e3126",
-    "git_hash": "8d88337cf3b37d530c523774d72b3ee05fd2209a"
   },
   {
     "date": "2023-01-31",
@@ -1851,18 +587,6 @@
     "git_hash": "745983ef05bfd9a67b1ebb9d90f6c5622fe1d597"
   },
   {
-    "date": "2023-02-06",
-    "version": "1.0.2-rc.77-arm64",
-    "container_hash": "4f5e8f61e39aa0821ba5bacce4df7e63819c1c8018532dc2c0e0e9d51485a01d",
-    "git_hash": "8ea9681b79f23657fd0b3dfcb67ae043a37e6b8c"
-  },
-  {
-    "date": "2023-02-06",
-    "version": "1.0.2-rc.77-amd64",
-    "container_hash": "01a4dbf2733838731e23dd285928e298b13e586ee9eee5f8ec1674d05499d5a1",
-    "git_hash": "8ea9681b79f23657fd0b3dfcb67ae043a37e6b8c"
-  },
-  {
     "date": "2023-02-07",
     "version": "1.0.1-arm64",
     "container_hash": "6b0271d7687ddc7ee11e8eea01bc1b05d6247bc2d26713c85ca89495fb70e5e0",
@@ -1879,54 +603,6 @@
     "version": "1.0.1-amd64",
     "container_hash": "fcc8c2629659f9ee16db713c6790959d8d95629ae3af621c4b81eb5f4b9aa8c5",
     "git_hash": "67d75b0523ae3f764eb6bbb5ca220c5bbae5ab3e"
-  },
-  {
-    "date": "2023-02-09",
-    "version": "1.0.2-rc.78-arm64",
-    "container_hash": "56b7aafd59d145fe5675e71eeec38b080b790a2a05a8bba17825302a239c9f3b",
-    "git_hash": "660e84da84fd029e64fa9331b565d1403f5807da"
-  },
-  {
-    "date": "2023-02-09",
-    "version": "1.0.2-rc.78-amd64",
-    "container_hash": "be6be288ed1dfe0bc45563e36bdb97b42c9f63e8903d4c687abecb3513319460",
-    "git_hash": "660e84da84fd029e64fa9331b565d1403f5807da"
-  },
-  {
-    "date": "2023-02-09",
-    "version": "1.0.2-rc.79-arm64",
-    "container_hash": "3da54e0a9d5a2b00795225f01a1ee473e3d51dfebef6e504b6e320f055fb0b5d",
-    "git_hash": "ad7d37e2ef7ea17042a4275543d7b0ac6158a429"
-  },
-  {
-    "date": "2023-02-09",
-    "version": "1.0.2-rc.79-amd64",
-    "container_hash": "16b8b5f67e683eedd6372442e9492f52541c6afb1a6b35d499fcf30927df5bb1",
-    "git_hash": "ad7d37e2ef7ea17042a4275543d7b0ac6158a429"
-  },
-  {
-    "date": "2023-02-10",
-    "version": "1.0.2-rc.80-arm64",
-    "container_hash": "2808cafaa4a2c2bbcc1a5dc2334abedd8633e13635cbf53a2246accfaca83d33",
-    "git_hash": "ba1427fba7b3fcb3645a202c80edbefe2ecbfa3c"
-  },
-  {
-    "date": "2023-02-10",
-    "version": "1.0.2-rc.80-amd64",
-    "container_hash": "b8f11312a665b3b76a3d8a5cda27476dec70b3d0352a00578d183ae4a31629e4",
-    "git_hash": "ba1427fba7b3fcb3645a202c80edbefe2ecbfa3c"
-  },
-  {
-    "date": "2023-02-10",
-    "version": "1.0.2-rc.81-arm64",
-    "container_hash": "c4fba562486f28c98e8444e9f76b8cdfeb61b35afbae5cc24021ceac51bc1b56",
-    "git_hash": "e268fe5dfa257ece5b7fc8abf598ccc8bbaa72f0"
-  },
-  {
-    "date": "2023-02-11",
-    "version": "1.0.2-rc.81-amd64",
-    "container_hash": "864cffbe2a3a2c5ce38814dbf0fda39a0dcc5186c81767167539524dbf1ea527",
-    "git_hash": "e268fe5dfa257ece5b7fc8abf598ccc8bbaa72f0"
   },
   {
     "date": "2023-02-14",
@@ -1965,42 +641,6 @@
     "git_hash": "67d75b0523ae3f764eb6bbb5ca220c5bbae5ab3e"
   },
   {
-    "date": "2023-02-21",
-    "version": "1.0.2-rc.82-arm64",
-    "container_hash": "57359f4baf59bcb43e51ba7fa6caa84b0d2e246dc857f13eb5238e763f74197d",
-    "git_hash": "6200093137fdc3167891b949f20d1cca140d5a99"
-  },
-  {
-    "date": "2023-02-21",
-    "version": "1.0.2-rc.82-amd64",
-    "container_hash": "315d8129d499d93777bb36dcd94c46dc013eb3b0472bd21f8137568ef165881b",
-    "git_hash": "6200093137fdc3167891b949f20d1cca140d5a99"
-  },
-  {
-    "date": "2023-02-21",
-    "version": "1.0.2-rc.83-arm64",
-    "container_hash": "0362caf5171fb7a8808ea5ca812f5d92ec58087c5a855e2b4b9adb117ea90906",
-    "git_hash": "2abb88f424e4896f6e0baadb14e26cc621500b2e"
-  },
-  {
-    "date": "2023-02-21",
-    "version": "1.0.2-rc.83-amd64",
-    "container_hash": "093cc4e6e560d7a1c1a07740bb5d6708fa83188645933f3d777908314f6458ce",
-    "git_hash": "2abb88f424e4896f6e0baadb14e26cc621500b2e"
-  },
-  {
-    "date": "2023-02-23",
-    "version": "1.0.2-rc.84-arm64",
-    "container_hash": "c927ea3adda54fcef23631413c5c7d78b2c4fd0245dcc3546559a381e93bba2b",
-    "git_hash": "df50e1ad98adb99016fb8fe61e2d7c7e72cfee10"
-  },
-  {
-    "date": "2023-02-23",
-    "version": "1.0.2-rc.84-amd64",
-    "container_hash": "02846a939a97a69d1e713a1952ebd4b36e995bd1ec1048127691a73893991318",
-    "git_hash": "df50e1ad98adb99016fb8fe61e2d7c7e72cfee10"
-  },
-  {
     "date": "2023-02-28",
     "version": "1.0.1-amd64",
     "container_hash": "381048abeb4e52470475dbaa57ffe591345a0e2cb41c01053822609021ad5cfb",
@@ -2017,42 +657,6 @@
     "version": "1.0.1-arm64",
     "container_hash": "7da79b97c9561051e3c116602e291b7281379b0f3cafcade8ba3e926f820bc68",
     "git_hash": "67d75b0523ae3f764eb6bbb5ca220c5bbae5ab3e"
-  },
-  {
-    "date": "2023-03-01",
-    "version": "1.0.2-rc.85-arm64",
-    "container_hash": "48d42067195c56870e94157fd0ef2d53e6e0b2c2a5c54ada0227fb20683841aa",
-    "git_hash": "11a72e853e84799d350dcee1286bc543387b35a6"
-  },
-  {
-    "date": "2023-03-01",
-    "version": "1.0.2-rc.85-amd64",
-    "container_hash": "f6c93afed33785cd0c848737562b2215ed6915ceb4632535be94b6ffd97fb8af",
-    "git_hash": "11a72e853e84799d350dcee1286bc543387b35a6"
-  },
-  {
-    "date": "2023-03-02",
-    "version": "1.0.2-rc.86-arm64",
-    "container_hash": "09f2f2e3d046bd7a2e4148336383d1ebfa6a268775d70885e6e7f96d37565f1a",
-    "git_hash": "b3d2692c1a330eb0da107312a4a3f7532948858c"
-  },
-  {
-    "date": "2023-03-02",
-    "version": "1.0.2-rc.86-amd64",
-    "container_hash": "75e7b84e9b420eeb8c6dc286e661ca11f5d138ea68c434c0760afb06a181837b",
-    "git_hash": "b3d2692c1a330eb0da107312a4a3f7532948858c"
-  },
-  {
-    "date": "2023-03-02",
-    "version": "1.0.2-rc.87-arm64",
-    "container_hash": "a299d76f48680e21319efed74a70c6d076b4d2ff5c607e968501b0b2b1ae49ff",
-    "git_hash": "fe4028658e5f87f92fe35d89d85f6fe9f4a710e1"
-  },
-  {
-    "date": "2023-03-02",
-    "version": "1.0.2-rc.87-amd64",
-    "container_hash": "1a93df209e2315e4a225b3a566aa4cb661639c9e021dd1f3b600393e0228b7f9",
-    "git_hash": "fe4028658e5f87f92fe35d89d85f6fe9f4a710e1"
   },
   {
     "date": "2023-03-07",
@@ -2073,78 +677,6 @@
     "git_hash": "67d75b0523ae3f764eb6bbb5ca220c5bbae5ab3e"
   },
   {
-    "date": "2023-03-08",
-    "version": "1.0.2-rc.88-arm64",
-    "container_hash": "25ae576519ff5e8bec38804e2aa1c565b4c8c8a5e0d77da1f2e80360ca146124",
-    "git_hash": "af73f8e05f1116efca93a81616d0329381b0b7a4"
-  },
-  {
-    "date": "2023-03-08",
-    "version": "1.0.2-rc.88-amd64",
-    "container_hash": "cc1ffbc4366aafcdcd8b9f7d8482df21847166ee047a3ee97a7213495df080d3",
-    "git_hash": "af73f8e05f1116efca93a81616d0329381b0b7a4"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "1.0.2-rc.89-amd64",
-    "container_hash": "0ccba3e1025318133fabb6f8428d8565c0dc75fc191f628e16325f886578f385",
-    "git_hash": "3193fdd25b382ef3514b5e84e8248cdbcac29dba"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "1.0.2-rc.90-amd64",
-    "container_hash": "75ab0cb1a611dcc66e62ed27738cfe1ca2229f3e499e4f532aea0544b4bebe12",
-    "git_hash": "992a7952e4a598656f32ef6289d9f85ccf97fc2c"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "1.0.2-rc.92-amd64",
-    "container_hash": "d027b54050ec3bc5dd3355c0c9f962540a30eb02bdd3adf1ec66b69e8b21ca8f",
-    "git_hash": "7c83ca505b9ffca9f36ed3c13cfec806f72030c4"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "1.0.2-rc.91-amd64",
-    "container_hash": "207b16d35b78fec53dbb8c53a35e1945f0480564fdfa4365898e2471ca143192",
-    "git_hash": "cc70ba48a08af4ab506d0a6d2d2fc2be755976a0"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "1.0.2-rc.93-amd64",
-    "container_hash": "e9c20c9f8751c38e5bad03030f6e7bd1869d77f2c24c9c415d4a751ef65169ce",
-    "git_hash": "597742728e741152b1089e80cca1f8b5cd037e0c"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "1.0.2-rc.89-arm64",
-    "container_hash": "e6eb0ed14043ade5ef5b325b02df024fe8bd6057071d1f4a1695e473c909092e",
-    "git_hash": "3193fdd25b382ef3514b5e84e8248cdbcac29dba"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "1.0.2-rc.90-arm64",
-    "container_hash": "ea59cde6815c80601cb50b1c8d28c4cb410eba687ee2698384e0a5085e45bc88",
-    "git_hash": "992a7952e4a598656f32ef6289d9f85ccf97fc2c"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "1.0.2-rc.91-arm64",
-    "container_hash": "7281e2698741d7614aaa4df1a3ffdf2b8dd7697c761c556ce42cb5867f5eaf20",
-    "git_hash": "cc70ba48a08af4ab506d0a6d2d2fc2be755976a0"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "1.0.2-rc.92-arm64",
-    "container_hash": "c7fb3db047207df9a294deeb49c116a6e1276a076c4161a06a69126da9744a84",
-    "git_hash": "7c83ca505b9ffca9f36ed3c13cfec806f72030c4"
-  },
-  {
-    "date": "2023-03-13",
-    "version": "1.0.2-rc.93-arm64",
-    "container_hash": "db006773f3f496d0fbcc0163ca101386ac3f10234cd2783edf703e362696b4f0",
-    "git_hash": "597742728e741152b1089e80cca1f8b5cd037e0c"
-  },
-  {
     "date": "2023-03-14",
     "version": "1.0.1-amd64",
     "container_hash": "1edf969af5ae2c44f9083b1ce1c859927f1fd535411d329273a10b9d3bfae835",
@@ -2155,102 +687,6 @@
     "version": "1.0.0",
     "container_hash": "0300f34ef44d449c801ae8ffe44b23e0bc191876368e4e5013460b360b587085",
     "git_hash": "745983ef05bfd9a67b1ebb9d90f6c5622fe1d597"
-  },
-  {
-    "date": "2023-03-16",
-    "version": "1.0.2-rc.94-arm64",
-    "container_hash": "1062a0bffe627dabd6d4bb443a5316a3eea41179a861e89bb9cb575d01cc389f",
-    "git_hash": "789479c2c6dffef9d98dc0dbba8cd282e445fec5"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "1.0.2-rc.94-amd64",
-    "container_hash": "3a36d95d0d1afcc82c740437b459cd4d4414bb5de72a24f761d14343549255eb",
-    "git_hash": "789479c2c6dffef9d98dc0dbba8cd282e445fec5"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "1.0.2-rc.95-amd64",
-    "container_hash": "702ba08e0f2c4bd073c3599d22ab24c5853fe00a0c09fda52deafdd9f851b191",
-    "git_hash": "5019bc9c557a7ab7068d23ab621d53377ca540aa"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "1.0.2-rc.96-amd64",
-    "container_hash": "984000282597ab690208c712f79f9197480a486be23c707a37765bdec32fe195",
-    "git_hash": "808f670d71f165bdd92eac42b49abc923ee2cd8c"
-  },
-  {
-    "date": "2023-03-16",
-    "version": "1.0.2-rc.95-arm64",
-    "container_hash": "26dab15522ee35dfdd8ce8431918fc81bc45bb00b075e0bdb0427f0e1ad45475",
-    "git_hash": "5019bc9c557a7ab7068d23ab621d53377ca540aa"
-  },
-  {
-    "date": "2023-03-16",
-    "version": "1.0.2-rc.96-arm64",
-    "container_hash": "fd8af2a546118165a484a5a7e878575031770634f5f4d88643efa4ded088c65d",
-    "git_hash": "808f670d71f165bdd92eac42b49abc923ee2cd8c"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "1.0.2-rc.97-arm64",
-    "container_hash": "94e41b898ef796f3963bc299cc16ae231254cb53921f861d823f9e4d2a3c4942",
-    "git_hash": "013c5a3262ab82984a2d9ce2d40b08d1df3b4594"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "1.0.2-rc.98-arm64",
-    "container_hash": "86ff04bb8fea9d52c8f80b1c68d14251ea2b31ddcad768cc43cda7c8355ace63",
-    "git_hash": "743866f3294310ac049dfd548d57bbe2ff6547aa"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "1.0.2-rc.98-amd64",
-    "container_hash": "568fa6cd7ea90294a15a75707eecdd1f0bb55460bc65210b690f6fe41e8f0cc1",
-    "git_hash": "743866f3294310ac049dfd548d57bbe2ff6547aa"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "1.0.2-rc.97-amd64",
-    "container_hash": "c4da590c5e54f08c3c6bcb59eea40bf47d856ee9d75b3f382f966acb093ecd14",
-    "git_hash": "013c5a3262ab82984a2d9ce2d40b08d1df3b4594"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "1.0.2-rc.99-arm64",
-    "container_hash": "7d591938a317c656f10978658e6488bca159d9edb1d536b01d5f3d517c2034ca",
-    "git_hash": "aefd168732ce923d408f8681ce7872ce061e0cfe"
-  },
-  {
-    "date": "2023-03-17",
-    "version": "1.0.2-rc.99-amd64",
-    "container_hash": "9912304f0eceb75a7223273f3463cccc3a284093f4e1ff11593f067ce50a0068",
-    "git_hash": "aefd168732ce923d408f8681ce7872ce061e0cfe"
-  },
-  {
-    "date": "2023-03-21",
-    "version": "1.0.2-rc.100-arm64",
-    "container_hash": "a1d3cf36fcc55821edaa7852e96bfadec006cdca0d5df2a0cb3f167e5f33e989",
-    "git_hash": "334179070651899980527d7eb19d8f1976a0670b"
-  },
-  {
-    "date": "2023-03-21",
-    "version": "1.0.2-rc.100-amd64",
-    "container_hash": "7c1b9c3481aba16a41c2c8bfdfc0b3ca89fd9c0aebf07ca2dc35723c4a62f0a3",
-    "git_hash": "334179070651899980527d7eb19d8f1976a0670b"
-  },
-  {
-    "date": "2023-03-21",
-    "version": "1.0.2-rc.101-arm64",
-    "container_hash": "0abef19e3ceb38ed413f92b6a761b921fd0b0b56561719e4531c8939c7bf36b2",
-    "git_hash": "8d7b71ec0b1ba7a971a10589bfe2701163f84f0b"
-  },
-  {
-    "date": "2023-03-21",
-    "version": "1.0.2-rc.101-amd64",
-    "container_hash": "78ad5e45c69fab13f35c6da841a300a958ddd494c7c32f084b26f2574ca38748",
-    "git_hash": "8d7b71ec0b1ba7a971a10589bfe2701163f84f0b"
   },
   {
     "date": "2023-03-21",
@@ -2271,18 +707,6 @@
     "git_hash": "67d75b0523ae3f764eb6bbb5ca220c5bbae5ab3e"
   },
   {
-    "date": "2023-03-23",
-    "version": "2.0.0-rc.0-amd64",
-    "container_hash": "0ad582ae6a0f79e6ee9343ffb0244c0b196af30ab2e863517e7310164c7d0ce5",
-    "git_hash": "0104bcdd2ea0197eee32a98a34d0e64f1132c355"
-  },
-  {
-    "date": "2023-03-23",
-    "version": "2.0.0-rc.0-arm64",
-    "container_hash": "3186146ece8acd062d629e6994a6f6bf9198c478636cf173e6972a198c3df055",
-    "git_hash": "0104bcdd2ea0197eee32a98a34d0e64f1132c355"
-  },
-  {
     "date": "2023-03-27",
     "version": "2.0.0-amd64",
     "container_hash": "a12fdfe848ff77e7098561902f2fc880ea307af6c81485b0c9a31861ab71bffc",
@@ -2293,30 +717,6 @@
     "version": "2.0.0-arm64",
     "container_hash": "bf6f22fdd7955e5ba7ac7985705c8995c1e0bc6b57b7292857da9146c263d67d",
     "git_hash": "f6f53ee394c04c3e93a8ba55e18b19e30f80155a"
-  },
-  {
-    "date": "2023-03-27",
-    "version": "2.0.1-rc.0-amd64",
-    "container_hash": "d2d93069b8e54fa3fa83554b36b81f9341f1f131980b8024f22600683c99d3fc",
-    "git_hash": "46593883d9ab28eda1e23fbc425d7aca139762a6"
-  },
-  {
-    "date": "2023-03-27",
-    "version": "2.0.1-rc.0-arm64",
-    "container_hash": "306cfb04a925fbe96569ba807b3e6588669a1af8748571e384a3d6e9a8fac372",
-    "git_hash": "46593883d9ab28eda1e23fbc425d7aca139762a6"
-  },
-  {
-    "date": "2023-03-27",
-    "version": "2.0.1-rc.1-amd64",
-    "container_hash": "a76334b937a60f29dbb510bae36e661e74b6048592272f218802f3b698d250cc",
-    "git_hash": "43cb8fdb80d33acfef0767e8cc6b2d93a713351a"
-  },
-  {
-    "date": "2023-03-27",
-    "version": "2.0.1-rc.1-arm64",
-    "container_hash": "44c9b39272fbb5d4b91867dd7dc837fbd0e552b8f8f2fe9448de4bcab0fe6234",
-    "git_hash": "43cb8fdb80d33acfef0767e8cc6b2d93a713351a"
   },
   {
     "date": "2023-03-27",
@@ -2361,30 +761,6 @@
     "git_hash": "67d75b0523ae3f764eb6bbb5ca220c5bbae5ab3e"
   },
   {
-    "date": "2023-03-31",
-    "version": "2.0.2-rc.0-amd64",
-    "container_hash": "39f646bc4a7c95e3cb50c2f47158e56fa84886b1d0d7f33c5f1a23692182a2d0",
-    "git_hash": "4cdbd3d0470fc16e3a0e17d7807930292cc8c060"
-  },
-  {
-    "date": "2023-03-31",
-    "version": "2.0.2-rc.0-arm64",
-    "container_hash": "2e53659ff2440e715f638e0c207508390fc040287c11441fed42ce36728229e7",
-    "git_hash": "4cdbd3d0470fc16e3a0e17d7807930292cc8c060"
-  },
-  {
-    "date": "2023-04-03",
-    "version": "2.0.2-rc.1-amd64",
-    "container_hash": "52a8eb2adaf8bc01f819ed5a22f9385eab49af623ee3d9138fbc0dca9359dcf0",
-    "git_hash": "9ad1f6754ad1cc002f3d1cb44405a0415f9a1628"
-  },
-  {
-    "date": "2023-04-03",
-    "version": "2.0.2-rc.1-arm64",
-    "container_hash": "2214724bc1477817a735d17a96b4bf201d9c64210e67bb71a53ff68923991b9a",
-    "git_hash": "9ad1f6754ad1cc002f3d1cb44405a0415f9a1628"
-  },
-  {
     "date": "2023-04-04",
     "version": "2.0.1-amd64",
     "container_hash": "e2e5f6d38ee7cfc1ee9942fddbfcaca01baa81e8bacfde22e7073ff86fabc533",
@@ -2407,18 +783,6 @@
     "version": "1.0.0",
     "container_hash": "8847ed53fa5438ba175fe9f9a34e47e5f46fbf10f30d460b4030042268eadfc7",
     "git_hash": "745983ef05bfd9a67b1ebb9d90f6c5622fe1d597"
-  },
-  {
-    "date": "2023-04-04",
-    "version": "2.1.0-rc.0-amd64",
-    "container_hash": "bceb1447265a7f8f0796abb2bcb2539f16177955d9e5f68dff81ef0721684deb",
-    "git_hash": "b8d71069936eca41f76d1836e14d68af7b214601"
-  },
-  {
-    "date": "2023-04-04",
-    "version": "2.1.0-rc.0-arm64",
-    "container_hash": "4302f957fa8632f438eb5cf11c69d0503bcb186e434ebfe5889b38777c225ca0",
-    "git_hash": "b8d71069936eca41f76d1836e14d68af7b214601"
   },
   {
     "date": "2023-04-04",
@@ -2479,18 +843,6 @@
     "version": "1.0.1-arm64",
     "container_hash": "2a3f49e7161b3b17c486bfcd71735e26bc6cb2ba606a00bc46e4f21eb0545657",
     "git_hash": "67d75b0523ae3f764eb6bbb5ca220c5bbae5ab3e"
-  },
-  {
-    "date": "2023-04-13",
-    "version": "2.1.1-rc.0-amd64",
-    "container_hash": "80348fef97bf7d97794a23e7b943abdf035f4e5094cff3f00634287cf727f541",
-    "git_hash": "eff468feddf50b7d8abe9bf7147a34d3f99bda5e"
-  },
-  {
-    "date": "2023-04-13",
-    "version": "2.1.1-rc.0-arm64",
-    "container_hash": "fd2984a0928858a1b56062b8caedf6769134a97b203552c58d25bdffd4030a4c",
-    "git_hash": "eff468feddf50b7d8abe9bf7147a34d3f99bda5e"
   },
   {
     "date": "2023-04-18",
@@ -2619,78 +971,6 @@
     "git_hash": "67d75b0523ae3f764eb6bbb5ca220c5bbae5ab3e"
   },
   {
-    "date": "2023-05-08",
-    "version": "2.2.0-rc.0-amd64",
-    "container_hash": "2034d40dbb96c883f8fb2851629e0d3715276f0ee4b37a307f6d26738f68685d",
-    "git_hash": "d13d6baaaa6f7d6988ae98250051fb49b1399616"
-  },
-  {
-    "date": "2023-05-08",
-    "version": "2.2.0-rc.0-arm64",
-    "container_hash": "5647b1882f1e58c150682792d480cb0cea38b95145e598eaa60d76aa8a963646",
-    "git_hash": "d13d6baaaa6f7d6988ae98250051fb49b1399616"
-  },
-  {
-    "date": "2023-05-19",
-    "version": "2.2.0-rc.1-amd64",
-    "container_hash": "c7cabe3456472fcabf8d2ce8a4186fb43d62c92acaa49365d506925e56b4d909",
-    "git_hash": "543e161964171ff918ae56c37787dcfd1b495cf2"
-  },
-  {
-    "date": "2023-05-19",
-    "version": "2.2.0-rc.1-arm64",
-    "container_hash": "561984269486f0b6468d9450053ff7e255598b6914eab70f93efad6ad261af4c",
-    "git_hash": "543e161964171ff918ae56c37787dcfd1b495cf2"
-  },
-  {
-    "date": "2023-05-24",
-    "version": "2.2.0-rc.2-amd64",
-    "container_hash": "1d9e0a759c98ee8849836aae1bb9cb920bb37b77caf2c3d59d5998b81476e94f",
-    "git_hash": "e8e02de330ca8287afbf313f6efa6a0a40b599bd"
-  },
-  {
-    "date": "2023-05-24",
-    "version": "2.2.0-rc.2-arm64",
-    "container_hash": "d8c05a2ee416e631b99fa2ea7e30475a2a3d3ee0cfa9a9abe06d9acca54737bd",
-    "git_hash": "e8e02de330ca8287afbf313f6efa6a0a40b599bd"
-  },
-  {
-    "date": "2023-05-26",
-    "version": "2.2.0-rc.3-amd64",
-    "container_hash": "c386735bca7038517f21fefe64f00633873049d0f95dcf9dc665167dc9728986",
-    "git_hash": "1e8d655d12c95a61738faa1e267ecf13d56af627"
-  },
-  {
-    "date": "2023-05-26",
-    "version": "2.2.0-rc.3-arm64",
-    "container_hash": "a8383d5dc0c46007dc421d09b1ef6ac3617fe51cf738d98da289a6148ff385b1",
-    "git_hash": "1e8d655d12c95a61738faa1e267ecf13d56af627"
-  },
-  {
-    "date": "2023-07-07",
-    "version": "2.2.0-rc.4-amd64",
-    "container_hash": "6d7ca5b774b197a0f834edb5eafa05941b70ee1751caabdafe65e1f90c1bf7ee",
-    "git_hash": "89facff828ecffe1497107332d84c1937d8a4288"
-  },
-  {
-    "date": "2023-07-07",
-    "version": "2.2.0-rc.4-arm64",
-    "container_hash": "cdcfba9c02206437590424ef980673a6f20ac14d0e9eb19be23dc8bf0c3af887",
-    "git_hash": "89facff828ecffe1497107332d84c1937d8a4288"
-  },
-  {
-    "date": "2023-07-10",
-    "version": "2.2.0-rc.5-amd64",
-    "container_hash": "6cf5a0c709d7740716bd01a0953d3c7e7c11a4781f87083f3c10cf2f8e58860e",
-    "git_hash": "3e68164bdd6ceff446e9f25fd2a92f562123cef0"
-  },
-  {
-    "date": "2023-07-10",
-    "version": "2.2.0-rc.5-arm64",
-    "container_hash": "6ac7a0957a5519b0c0f75a84e78082c6695375a05905048710cd4e7b2ef4f0c0",
-    "git_hash": "3e68164bdd6ceff446e9f25fd2a92f562123cef0"
-  },
-  {
     "date": "2023-07-18",
     "version": "2.2.0-amd64",
     "container_hash": "05c19e13da185539f0baa172edabf689a3ed09ada8a0410ca75d3073ace222ef",
@@ -2701,17 +981,5 @@
     "version": "2.2.0-arm64",
     "container_hash": "f1fa0d758e0cd753996bd78ac395c72c26bf71d6095a9518e35dae9cb5f3f855",
     "git_hash": "b321e5e377fb3354627dcd347a0022bd3c327891"
-  },
-  {
-    "date": "2023-08-16",
-    "version": "2.2.1-rc.0-amd64",
-    "container_hash": "2f56e61c1b2ceb092b40dcb033f4391ac1eee772e6e40393ba5d959856329664",
-    "git_hash": "aae5f9fbcd5daa5bc6eb357bd42a853085658b0e"
-  },
-  {
-    "date": "2023-08-16",
-    "version": "2.2.1-rc.0-arm64",
-    "container_hash": "f31be79d37fb505969af4ce794a371687ce743ada5e0554a166d7b6c145ba937",
-    "git_hash": "aae5f9fbcd5daa5bc6eb357bd42a853085658b0e"
   }
 ]


### PR DESCRIPTION
This is the result of `jq 'map(select(.version | test("^[^-]*(-amd64|-arm64)?$")))'`. The filter allows:
- All versions that have no `-` character in them.
- All versions that have no `-` character in them, except for a terminating `-amd64` or `-arm64`.